### PR TITLE
fix: add missing packages to modules

### DIFF
--- a/modules/cong.js
+++ b/modules/cong.js
@@ -17,6 +17,7 @@ const { webdavLs, webdavExists, webdavStatus } = require("./webdav");
 const $ = require("jquery"); 
 const fs = require("fs-extra");
 const path = require("upath");
+const escape = require("escape-html");
 const glob = require("fast-glob");
 const os = require("os");
 const dayjs = require("dayjs");

--- a/modules/converters.js
+++ b/modules/converters.js
@@ -8,6 +8,7 @@ const path = require("upath");
 const $ = require("jquery");
 const fs = require("fs-extra");
 const glob = require("fast-glob");
+const escape = require("escape-html");
 
 dayjs.extend(require("dayjs/plugin/isoWeek"));
 dayjs.extend(require("dayjs/plugin/isBetween"));

--- a/modules/log.js
+++ b/modules/log.js
@@ -8,6 +8,7 @@ const { get } = require("./store");
 const os = require("os");
 const $ = require("jquery");
 const remote = require("@electron/remote");
+const escape = require("escape-html");
 const path = require("upath");
 const i18n = require("i18n");
 i18n.configure({

--- a/modules/prefs.js
+++ b/modules/prefs.js
@@ -6,13 +6,14 @@ const { log, notifyUser } = require("./log");
 const { translate } = require("./lang");
 const { get, set, setPath, setPref } = require("./store");
 const { perf } = require("./requests");
-const { toggleScreen } = require("./ui");
+const { toggleScreen, unconfirm } = require("./ui");
 const { shortcutSet, shortcutsUnset } = require("./obs");
 // External modules
 const fs = require("fs-extra");
 const v8 = require("v8");
 const os = require("os");
 const path = require("upath");
+const glob = require("fast-glob");
 const $ = require("jquery");
 const remote = require("@electron/remote");
 const datetime = require("flatpickr");

--- a/modules/ui.js
+++ b/modules/ui.js
@@ -11,6 +11,7 @@ const { translate } = require("./lang");
 const $ = require("jquery");
 const remote = require("@electron/remote");
 const bootstrap = require("bootstrap");
+const escape = require("escape-html");
 const glob = require("fast-glob");
 const path = require("upath");
 


### PR DESCRIPTION
Various packages were missing the escape package. It was not giving an error, because it was using the deprecated built-in escape function.

Also the prefs module missed the glob package and the unconfirm method from ui module.