### PR TITLE
feat: add GitLocalize description

### DIFF
--- a/GITLOCALIZE.md
+++ b/GITLOCALIZE.md
@@ -1,0 +1,9 @@
+# Dear translators
+
+Thank you for your interest in translating this project! This is the GitLocalize project for M³.
+
+After having translated a file, please make sure to also send the a pull request to GitHub. Only then can it be accepted and included in the next release.
+
+Kind regards,
+
+[@sircharlo](/users/sircharlo)


### PR DESCRIPTION
This GITLOCALIZE.md file can be used to display a description on GitLocalize (see [GitLocalize for the docs site](https://gitlocalize.com/repo/8096) for an example).

You can enable this by going into the GitLocalize settings and enabling `Display project description`. There you can paste the url to this GITLOCALIZE.md