### PR TITLE
feat: add song-picker in present mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -301,7 +301,15 @@ if (gotTheLock) {
   // IpcMain events for the media window
   ipcMain.on(
     'showMedia',
-    (_e, media: { path: string; start?: string; end?: string } | null) => {
+    (
+      _e,
+      media: {
+        src: string
+        stream?: boolean
+        start?: string
+        end?: string
+      } | null
+    ) => {
       mediaWin?.webContents.send('showMedia', media)
       win?.webContents.send('showingMedia', [!!media, !!media?.start])
     }

--- a/src/renderer/components/media/MediaControls.vue
+++ b/src/renderer/components/media/MediaControls.vue
@@ -28,6 +28,9 @@
             </v-list-item>
           </v-list>
         </v-menu>
+        <v-btn icon aria-label="Add song" @click="addSong = !addSong">
+          <font-awesome-icon :icon="faMusic" size="lg" />
+        </v-btn>
       </v-col>
       <v-col class="text-center d-flex justify-center">
         <v-btn
@@ -120,6 +123,36 @@
         ${listHeight}
       `"
     >
+      <form-input
+        v-if="addSong"
+        id="select-song"
+        ref="songPicker"
+        v-model="song"
+        field="autocomplete"
+        :items="songs"
+        item-text="title"
+        item-value="safeName"
+        hide-details="auto"
+        class="pa-4"
+        clearable
+        :loading="loadingSongs"
+        return-object
+      />
+      <v-list v-if="song" class="ma-4">
+        <media-item
+          :key="song.url"
+          :src="song.url"
+          :play-now="song.play"
+          :stop-now="song.stop"
+          :deactivate="song.deactivate"
+          :media-active="mediaActive"
+          :video-active="videoActive"
+          :show-prefix="showPrefix"
+          :streaming-file="song"
+          @playing="setIndex(-1)"
+          @deactivated="song.deactivate = false"
+        />
+      </v-list>
       <draggable
         v-model="items"
         tag="v-list"
@@ -158,6 +191,7 @@ import {
   faRotateRight,
   faBackward,
   faForward,
+  faMusic,
   faGlobe,
   faSquareCheck,
   faEllipsisVertical,
@@ -165,6 +199,7 @@ import {
   faFolderOpen,
   IconDefinition,
 } from '@fortawesome/free-solid-svg-icons'
+import { VideoFile } from '~/types'
 import { MS_IN_SEC } from '~/constants/general'
 export default defineComponent({
   components: {
@@ -190,6 +225,10 @@ export default defineComponent({
       dragging: false,
       sortable: false,
       loading: true,
+      addSong: false,
+      song: null as null | VideoFile,
+      songs: [] as VideoFile[],
+      loadingSongs: true,
       showPrefix: false,
       items: [] as {
         id: string
@@ -240,6 +279,9 @@ export default defineComponent({
     date(): string {
       return this.$route.query.date as string
     },
+    faMusic() {
+      return faMusic
+    },
     faEllipsisVertical() {
       return faEllipsisVertical
     },
@@ -263,6 +305,9 @@ export default defineComponent({
     },
   },
   watch: {
+    song() {
+      this.addSong = false
+    },
     async mediaActive(val: boolean) {
       this.items.forEach((item) => {
         item.play = false
@@ -286,7 +331,8 @@ export default defineComponent({
   beforeDestroy() {
     ipcRenderer.removeAllListeners('play')
   },
-  mounted() {
+  async mounted() {
+    const promise = this.getSongs()
     this.getMedia()
     ipcRenderer.on('play', (_e, type: 'next' | 'previous') => {
       if (type === 'next') {
@@ -295,8 +341,15 @@ export default defineComponent({
         this.previous()
       }
     })
+
+    await promise
   },
   methods: {
+    async getSongs() {
+      this.loadingSongs = true
+      this.songs = await this.$getSongs()
+      this.loadingSongs = false
+    },
     openWebsite() {
       ipcRenderer.send(
         'openWebsite',
@@ -310,6 +363,7 @@ export default defineComponent({
     setIndex(index: number) {
       const previousItem = this.items[this.currentIndex]
       if (previousItem && this.currentIndex !== index) {
+        // @ts-ignore
         previousItem.deactivate = true
       }
       this.currentIndex = index

--- a/src/renderer/components/media/MediaControls.vue
+++ b/src/renderer/components/media/MediaControls.vue
@@ -370,9 +370,7 @@ export default defineComponent({
     },
     previous() {
       if (this.mediaActive) {
-        if (this.song && this.currentIndex === -1) {
-          this.song.stop = true
-        } else {
+        if (this.currentIndex >= 0) {
           this.items[this.currentIndex].stop = true
         }
       } else if (this.currentIndex > 0) {
@@ -393,9 +391,7 @@ export default defineComponent({
     },
     next() {
       if (this.mediaActive) {
-        if (this.song && this.currentIndex === -1) {
-          this.song.stop = true
-        } else {
+        if (this.currentIndex >= 0) {
           this.items[this.currentIndex].stop = true
         }
       } else if (this.currentIndex < this.items.length - 1) {

--- a/src/renderer/components/media/MediaControls.vue
+++ b/src/renderer/components/media/MediaControls.vue
@@ -370,7 +370,11 @@ export default defineComponent({
     },
     previous() {
       if (this.mediaActive) {
-        this.items[this.currentIndex].stop = true
+        if (this.song && this.currentIndex === -1) {
+          this.song.stop = true
+        } else {
+          this.items[this.currentIndex].stop = true
+        }
       } else if (this.currentIndex > 0) {
         this.currentIndex--
         this.items[this.currentIndex].play = true
@@ -389,7 +393,11 @@ export default defineComponent({
     },
     next() {
       if (this.mediaActive) {
-        this.items[this.currentIndex].stop = true
+        if (this.song && this.currentIndex === -1) {
+          this.song.stop = true
+        } else {
+          this.items[this.currentIndex].stop = true
+        }
       } else if (this.currentIndex < this.items.length - 1) {
         this.currentIndex++
         this.items[this.currentIndex].play = true

--- a/src/renderer/components/media/MediaItem.vue
+++ b/src/renderer/components/media/MediaItem.vue
@@ -45,7 +45,7 @@
       </v-list-item-content>
       <v-list-item-action class="align-self-center d-flex flex-row">
         <v-btn
-          v-if="streamingFile && !streamDownloaded"
+          v-if="streamingFile && !streamDownloaded && !active"
           :loading="downloading"
           class="mr-2"
           @click="downloadSong()"

--- a/src/renderer/components/media/MediaVideo.vue
+++ b/src/renderer/components/media/MediaVideo.vue
@@ -139,6 +139,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+    stream: {
+      type: Boolean,
+      default: false,
+    },
     tempClipped: {
       type: Object,
       default: null,
@@ -190,7 +194,10 @@ export default defineComponent({
       >
     },
     url(): string {
-      return pathToFileURL(this.src).href + (this.thumbnail ? '' : '#t=5')
+      return (
+        (this.stream ? this.src : pathToFileURL(this.src).href) +
+        (this.thumbnail ? '' : '#t=5')
+      )
     },
     thumbnail(): string | null {
       let thumbnail: string | null | undefined

--- a/src/renderer/pages/add.vue
+++ b/src/renderer/pages/add.vue
@@ -228,7 +228,6 @@ import {
   BYTES_IN_MB,
   HUNDRED_PERCENT,
   MS_IN_SEC,
-  NR_OF_KINGDOM_SONGS,
 } from '~/constants/general'
 export default defineComponent({
   name: 'AddPage',
@@ -628,33 +627,7 @@ export default defineComponent({
     },
     async getSongs() {
       this.loadingSongs = true
-      const result = (await this.$getMediaLinks({
-        pubSymbol: this.$store.state.media.songPub,
-        format: 'MP4',
-      })) as VideoFile[]
-
-      const fallbackLang = this.$getPrefs('media.langFallback') as string
-
-      if (fallbackLang && result.length < NR_OF_KINGDOM_SONGS) {
-        const fallback = (await this.$getMediaLinks({
-          pubSymbol: this.$store.state.media.songPub,
-          format: 'MP4',
-          lang: fallbackLang,
-        })) as VideoFile[]
-
-        fallback.forEach((song) => {
-          if (!result.find((s) => s.track === song.track)) {
-            result.push(song)
-          }
-        })
-        result.sort((a, b) => a.track - b.track)
-      }
-
-      result.forEach((song) => {
-        song.safeName =
-          this.$sanitize(`- ${this.$translate('song')} ${song.title}`) + '.mp4'
-      })
-      this.songs = result
+      this.songs = await this.$getSongs()
       this.loadingSongs = false
     },
     getExistingMedia() {

--- a/src/renderer/types/vue-shim.d.ts
+++ b/src/renderer/types/vue-shim.d.ts
@@ -104,6 +104,7 @@ interface CustomProps {
     setProgress?: (loaded: number, total: number, global?: boolean) => void
   ) => Promise<void>
   $getScenes: (current: boolean = false) => Promise<string[] | string>
+  $getSongs: () => Promise<VideoFile[]>
   $getWeMedia: (
     date: string,
     setProgress?: (loaded: number, total: number, global?: boolean) => void


### PR DESCRIPTION
It works as follows:
- Click music icon in media controls in presentation mode to toggle song picker
- Select a song and it gets added to the top of the media list
- If the song already exists in the cache, it will use that local file, otherwise it will stream the song and have a download option
- After downloading the song, the local cache file will be used instead of streaming it
- In both scenarios, the song can be paused and scrubbed and custom start and stop times can be set
- The song can **NOT** be moved by enabling the sort feature and cannot be played/stopped using the keyboard shortcuts

Related to #845