### PR TITLE
Fix/several fixes

### DIFF
--- a/src/renderer/components/media/MediaList.vue
+++ b/src/renderer/components/media/MediaList.vue
@@ -17,7 +17,6 @@
       :key="item.safeName"
       dense
       :disabled="item.loading"
-      @click="atClick(item)"
     >
       <v-list-item-action v-if="item.loading" class="my-0">
         <v-progress-circular indeterminate size="16" width="2" />
@@ -26,19 +25,22 @@
         v-else-if="!item.recurring && (item.isLocal || item.congSpecific)"
         class="my-0"
       >
-        <font-awesome-icon
-          v-if="item.color === 'warning'"
-          :icon="faSquareMinus"
-          class="warning--text"
-          size="xs"
-        />
+        <v-btn v-if="item.color === 'warning'" icon @click="atClick(item)">
+          <font-awesome-icon
+            :icon="faSquareMinus"
+            class="warning--text"
+            size="xs"
+          />
+        </v-btn>
         <v-tooltip v-else right :value="true">
           <template #activator="data">
-            <font-awesome-icon
-              :icon="faSquareMinus"
-              class="error--text"
-              size="xs"
-            />
+            <v-btn icon @click="atClick(item)">
+              <font-awesome-icon
+                :icon="faSquareMinus"
+                class="error--text"
+                size="xs"
+              />
+            </v-btn>
           </template>
           <span>{{ $t('clickAgain') }}</span>
         </v-tooltip>
@@ -47,8 +49,10 @@
         <font-awesome-icon :icon="faSquarePlus" size="xs" />
       </v-list-item-action>
       <v-list-item-action v-else class="my-0">
-        <font-awesome-icon v-if="item.hidden" :icon="faSquare" size="xs" />
-        <font-awesome-icon v-else :icon="faSquareCheck" size="xs" />
+        <v-btn icon @click="atClick(item)">
+          <font-awesome-icon v-if="item.hidden" :icon="faSquare" size="xs" />
+          <font-awesome-icon v-else :icon="faSquareCheck" size="xs" />
+        </v-btn>
       </v-list-item-action>
       <v-hover v-slot="{ hover }">
         <v-list-item-content>

--- a/src/renderer/components/media/MediaList.vue
+++ b/src/renderer/components/media/MediaList.vue
@@ -45,12 +45,18 @@
           <span>{{ $t('clickAgain') }}</span>
         </v-tooltip>
       </v-list-item-action>
-      <v-list-item-action v-else-if="item.isLocal === undefined" class="my-0">
-        <font-awesome-icon :icon="faSquarePlus" size="xs" />
-      </v-list-item-action>
       <v-list-item-action v-else class="my-0">
         <v-btn icon @click="atClick(item)">
-          <font-awesome-icon v-if="item.hidden" :icon="faSquare" size="xs" />
+          <font-awesome-icon
+            v-if="item.isLocal === undefined"
+            :icon="faSquarePlus"
+            size="xs"
+          />
+          <font-awesome-icon
+            v-else-if="item.hidden"
+            :icon="faSquare"
+            size="xs"
+          />
           <font-awesome-icon v-else :icon="faSquareCheck" size="xs" />
         </v-btn>
       </v-list-item-action>


### PR DESCRIPTION
@sircharlo, I think we finally got him! I was just shown a video of a user trying to rename a file. He misclicked and clicked on the filename and then clicked on the pencil icon to rename. But that second click activated the delete function. Now the delete and hide actions are only activated when actually clicking on the icon and not on the filename.

Related to #682