### PR TITLE
fix: correctly fetch wt songs for feb 2023 and later

### DIFF
--- a/src/renderer/constants/general.ts
+++ b/src/renderer/constants/general.ts
@@ -45,6 +45,7 @@ export const CHAR_GT = 62
 
 // JW Specific
 export const JAN_2008 = 20080101
+export const FEB_2023 = 20230200
 export const NR_OF_KINGDOM_SONGS = 151
 export const BIBLE_READING_PAR_NR = 12
 

--- a/src/renderer/plugins/media.ts
+++ b/src/renderer/plugins/media.ts
@@ -1290,20 +1290,7 @@ const plugin: Plugin = (
 
       images.forEach((img) => promises.push(addImgToPart(date, issue, img)))
 
-      let songs = $query(
-        db,
-        `SELECT DocumentMultimedia.MultimediaId, DocumentMultimedia.DocumentId, CategoryType, KeySymbol, Track, IssueTagNumber, MimeType
-         FROM DocumentMultimedia
-         INNER JOIN Multimedia
-           ON DocumentMultimedia.MultimediaId = Multimedia.MultimediaId
-         INNER JOIN DocumentExtract
-           ON DocumentExtract.DocumentId = DocumentMultimedia.DocumentId
-           AND DocumentExtract.BeginParagraphOrdinal = DocumentMultimedia.BeginParagraphOrdinal
-         WHERE DocumentMultimedia.DocumentId = ${docId}
-           AND CategoryType <> 9
-           AND CategoryType <> 8
-         GROUP BY DocumentMultimedia.MultimediaId`
-      ) as MultiMediaItem[]
+      let songs: MultiMediaItem[] = []
 
       // Watchtowers before Feb 2023 didn't include songs in DocumentMultimedia
       if (+issue < FEB_2023) {
@@ -1316,6 +1303,21 @@ const plugin: Plugin = (
           WHERE DataType = 2
           ORDER BY BeginParagraphOrdinal
           LIMIT 2 OFFSET ${2 * weekNr}`
+        ) as MultiMediaItem[]
+      } else {
+        songs = $query(
+          db,
+          `SELECT DocumentMultimedia.MultimediaId, DocumentMultimedia.DocumentId, CategoryType, KeySymbol, Track, IssueTagNumber, MimeType
+         FROM DocumentMultimedia
+         INNER JOIN Multimedia
+           ON DocumentMultimedia.MultimediaId = Multimedia.MultimediaId
+         INNER JOIN DocumentExtract
+           ON DocumentExtract.DocumentId = DocumentMultimedia.DocumentId
+           AND DocumentExtract.BeginParagraphOrdinal = DocumentMultimedia.BeginParagraphOrdinal
+         WHERE DocumentMultimedia.DocumentId = ${docId}
+           AND CategoryType <> 9
+           AND CategoryType <> 8
+         GROUP BY DocumentMultimedia.MultimediaId`
         ) as MultiMediaItem[]
       }
 


### PR DESCRIPTION
## Proposed Changes

A different approach to get wt songs for wt issues February 2023 and later. I've checked for February and March and also checked if American Sign Language uses KeySymbol 'sjjm'.

Related to #1730
