### PR TITLE
feat: possibility to force critical updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ The tests are written using [Playwright](https://playwright.dev/). Playwright is
 
 To release a new version of the application, you first create a draft release on GitHub. Then, you can change the [package.json](package.json) version to the desired version and commit the changes with the message `chore(release): vx.x.x` (e.g. `chore(release): v23.3.1`). Then, the build/release workflow will be executed and will fill the release draft with the new artifacts. After that, you can add a description of the release (features, bug fixes, etc.) and publish it.
 
+If a release contains a critical bug fix, you can add `[critical]` to the release title. This will override the `Disable non-critical automatic app updates` setting and will force all users to update.
+
 ### Contribute to the documentation site
 
 More information about contributing to the documentation site specifically can be found in the [CONTRIBUTING.md](https://github.com/sircharlo/meeting-media-manager/blob/docs/CONTRIBUTING.md) of the docs branch.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -578,14 +578,18 @@ if (gotTheLock) {
       })
     }
   })
-  autoUpdater.on('update-downloaded', () => {
-    updateDownloaded = true
-    win?.webContents.send('notifyUser', [
-      'updateDownloaded',
-      {
-        persistent: true,
-      },
-    ])
+  autoUpdater.on('update-downloaded', (e) => {
+    if (e.releaseName?.includes('[critical]')) {
+      autoUpdater.quitAndInstall(false)
+    } else {
+      updateDownloaded = true
+      win?.webContents.send('notifyUser', [
+        'updateDownloaded',
+        {
+          persistent: true,
+        },
+      ])
+    }
   })
 
   // When ready create main window

--- a/src/renderer/locales/en.json
+++ b/src/renderer/locales/en.json
@@ -20,7 +20,7 @@
   "customCachePath": "Custom cache path (for publications, etc.)",
   "dark": "Dark",
   "delete": "Delete",
-  "disableAutoUpdate": "Disable automatic app update",
+  "disableAutoUpdate": "Disable non-critical automatic app updates",
   "disableHardwareAcceleration": "Disable hardware acceleration <em>(Note: Only enable this setting if you are experiencing issues with media presentation. Changing this setting will cause M³ to restart.)</em>",
   "dontForgetToGetMedia": "Don't forget to update the media folders on the computer used to present media at congregation meetings!",
   "downloadShuffleMusic": "Download all songs for background music",


### PR DESCRIPTION
## Proposed Changes

The question remains, which version do we implement:

When an available update title contains `[critical]`:
1. Immediately quit the app, update and restart
2. Update as soon as the application closes

Or, implement option 1 for `[critical]` and option 2 for `[important]`.

Related to #1732
