### PR TITLE
fix: preserve user media and custom sections on pinyin toggle

### DIFF
--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -1144,6 +1144,26 @@ onMounted(() => {
       fetchMedia();
     },
   );
+
+  useEventListener(globalThis, 'pinyin-songs-toggled', () => {
+    // Clear only standard section items and reset status to force re-fetch,
+    // preserving custom/imported sections, user-added media, and config data
+    const days = lookupPeriod.value?.[currentCongregation.value] ?? [];
+    days.forEach((day) => {
+      day.mediaSections.forEach((s) => {
+        if (
+          s.config.uniqueId !== 'imported-media' &&
+          !s.config.uniqueId.startsWith('custom-')
+        ) {
+          // Keep user-added items, clear fetched items
+          s.items =
+            s.items?.filter((item) => item.source === 'additional') ?? [];
+        }
+      });
+      day.status = null;
+    });
+    fetchMedia();
+  });
 });
 
 const { post: postCustomBackground } = useBroadcastChannel<string, string>({


### PR DESCRIPTION
## Summary
- Previously, toggling pinyin songs cleared all `mediaSections` entirely (`day.mediaSections = []`), destroying user-added media items and custom section configurations
- Now only clears fetched items from standard sections while preserving:
  - User-added items (`source: 'additional'`)
  - Custom/imported sections
  - Section config data

## Test plan
- [ ] Add custom media items to a meeting date
- [ ] Toggle pinyin songs on/off
- [ ] Verify custom/imported media items are preserved after toggle
- [ ] Verify standard meeting media is re-fetched correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)