### PR TITLE
feat: add pinyin song substitution for additional remote videos

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -2876,6 +2876,7 @@ export const downloadAdditionalRemoteVideo = async (
     // Pinyin song substitution: use local pinyin file instead of downloading
     if (
       song &&
+      currentSettings?.lang === 'CHS' &&
       currentSettings?.enablePinyinSongs &&
       currentSettings?.pinyinSongFolder
     ) {


### PR DESCRIPTION
## Summary
- When pinyin songs are enabled and a matching local pinyin file exists, use it instead of downloading the standard song video
- Checks for pinyin file pattern `sjjm_s-Pi_CHS_{trackNum}_r720P.mp4` in the configured pinyin song folder
- Falls through to normal download if no pinyin file found

## Test plan
- [ ] Enable pinyin songs and set a pinyin song folder with matching files
- [ ] Add a song via the song picker dialog
- [ ] Verify the local pinyin version is used instead of downloading
- [ ] Verify normal download works when no pinyin file exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)