### PR TITLE
Fix Electron errno error typing

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -332,13 +332,13 @@ if (gotTheLock) {
 }
 
 // Silence EPIPE errors on stdout/stderr (common on Linux when quitting)
-process.stdout.on('error', (err) => {
+process.stdout.on('error', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EPIPE') return;
   captureElectronError(err, {
     contexts: { fn: { name: 'process.stdout.on(error)' } },
   });
 });
-process.stderr.on('error', (err) => {
+process.stderr.on('error', (err: NodeJS.ErrnoException) => {
   if (err.code === 'EPIPE') return;
   captureElectronError(err, {
     contexts: { fn: { name: 'process.stderr.on(error)' } },


### PR DESCRIPTION
### Motivation
- Resolve TypeScript `TS2339` errors where `err.code` was accessed on an untyped `Error` in Electron stdout/stderr error handlers by giving the error parameter a type that includes `code`.

### Description
- Annotate the `process.stdout.on('error', ...)` and `process.stderr.on('error', ...)` callbacks in `src-electron/electron-main.ts` with `err: NodeJS.ErrnoException`, preserving the existing `EPIPE` guard and error reporting.

### Testing
- Ran `./node_modules/.bin/vue-tsc --noEmit -p tsconfig.json`, which completed successfully.
- Ran `./node_modules/.bin/eslint -c ./eslint.config.js src-electron/electron-main.ts`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb41fa087c8331adf1f6e56f160612)