### PR TITLE
Fix macOS main window relaunch handling

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -35,6 +35,7 @@ import 'src-electron/main/security';
 import {
   authorizedClose,
   createMainWindow,
+  focusMainWindow,
   mainWindowInfo,
 } from 'src-electron/main/window/window-main';
 import upath from 'upath';
@@ -184,11 +185,8 @@ if (gotTheLock) {
 
   app.on('second-instance', () => {
     // Someone tried to run a second instance, we should focus our globalThis.
-    if (mainWindowInfo.mainWindow && !mainWindowInfo.mainWindow.isDestroyed()) {
-      if (mainWindowInfo.mainWindow.isMinimized())
-        mainWindowInfo.mainWindow.restore();
-      mainWindowInfo.mainWindow.show();
-    }
+    app.focus({ steal: true });
+    if (!focusMainWindow()) createWindowAndCaptureErrors();
   });
 
   if (PLATFORM === 'win32') {
@@ -322,7 +320,7 @@ if (gotTheLock) {
   });
 
   app.on('activate', () => {
-    createWindowAndCaptureErrors();
+    if (!focusMainWindow()) createWindowAndCaptureErrors();
   });
 
   createWindowAndCaptureErrors();

--- a/src-electron/main/__tests__/window-main.test.ts
+++ b/src-electron/main/__tests__/window-main.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAllWindows = vi.fn();
+const createWindow = vi.fn();
+const closeOtherWindows = vi.fn();
+const sendToWindow = vi.fn();
+const createMediaWindow = vi.fn();
+const cancelAllDownloads = vi.fn();
+const setAppQuitting = vi.fn();
+const setShouldQuit = vi.fn();
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows,
+  },
+}));
+
+vi.mock('src-electron/constants', () => ({
+  PLATFORM: 'darwin',
+  PRODUCT_NAME: 'Meeting Media Manager',
+}));
+
+vi.mock('src-electron/main/downloads', () => ({
+  cancelAllDownloads,
+}));
+
+vi.mock('src-electron/main/session', () => ({
+  setAppQuitting,
+  setShouldQuit,
+}));
+
+vi.mock('src-electron/main/window/window-base', () => ({
+  closeOtherWindows,
+  createWindow,
+  sendToWindow,
+}));
+
+vi.mock('src-electron/main/window/window-media', () => ({
+  createMediaWindow,
+  moveMediaWindowThrottled: vi.fn(),
+}));
+
+describe('window-main', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAllWindows.mockReturnValue([]);
+  });
+
+  it('reuses an existing main window discovered from BrowserWindow.getAllWindows', async () => {
+    const existingWindow = {
+      focus: vi.fn(),
+      getTitle: vi.fn(() => 'Meeting Media Manager'),
+      isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => false),
+      show: vi.fn(),
+    };
+
+    getAllWindows.mockReturnValue([existingWindow]);
+
+    const { createMainWindow, mainWindowInfo } =
+      await import('../window/window-main');
+
+    mainWindowInfo.mainWindow = null;
+
+    createMainWindow();
+
+    expect(createWindow).not.toHaveBeenCalled();
+    expect(existingWindow.show).toHaveBeenCalledOnce();
+    expect(existingWindow.focus).toHaveBeenCalledOnce();
+    expect(mainWindowInfo.mainWindow).toBe(existingWindow);
+  });
+
+  it('restores a minimized main window before focusing it', async () => {
+    const minimizedWindow = {
+      focus: vi.fn(),
+      getTitle: vi.fn(() => 'Meeting Media Manager'),
+      isDestroyed: vi.fn(() => false),
+      isMinimized: vi.fn(() => true),
+      restore: vi.fn(),
+      show: vi.fn(),
+    };
+
+    getAllWindows.mockReturnValue([minimizedWindow]);
+
+    const { focusMainWindow, mainWindowInfo } =
+      await import('../window/window-main');
+
+    mainWindowInfo.mainWindow = null;
+
+    expect(focusMainWindow()).toBe(true);
+    expect(minimizedWindow.restore).toHaveBeenCalledOnce();
+    expect(minimizedWindow.show).toHaveBeenCalledOnce();
+    expect(minimizedWindow.focus).toHaveBeenCalledOnce();
+  });
+});

--- a/src-electron/main/window/window-main.ts
+++ b/src-electron/main/window/window-main.ts
@@ -1,6 +1,5 @@
-import type { BrowserWindow } from 'electron';
-
-import { PLATFORM } from 'src-electron/constants';
+import { BrowserWindow } from 'electron';
+import { PLATFORM, PRODUCT_NAME } from 'src-electron/constants';
 import { cancelAllDownloads } from 'src-electron/main/downloads';
 import { setAppQuitting, setShouldQuit } from 'src-electron/main/session';
 import {
@@ -18,6 +17,7 @@ export const mainWindowInfo = {
 };
 
 let closeAttempts = 0;
+let isCreatingMainWindow = false;
 
 export const authorizedClose = {
   authorized: false,
@@ -31,42 +31,73 @@ export function createMainWindow() {
   setAppQuitting(false);
 
   // If the window is already open, just focus it
+  if (focusMainWindow() || isCreatingMainWindow) return;
+
+  isCreatingMainWindow = true;
+
+  try {
+    // Create the browser window
+    mainWindowInfo.mainWindow = createWindow('main');
+
+    mainWindowInfo.mainWindow.on('move', moveMediaWindowThrottled);
+    if (PLATFORM !== 'darwin')
+      mainWindowInfo.mainWindow.on('moved', moveMediaWindowThrottled); // On macOS, the 'moved' event is just an alias for 'move'
+
+    mainWindowInfo.mainWindow.on('close', (e) => {
+      if (
+        mainWindowInfo.mainWindow &&
+        (authorizedClose.authorized || closeAttempts > 2)
+      ) {
+        cancelAllDownloads();
+        closeOtherWindows(mainWindowInfo.mainWindow);
+      } else {
+        setShouldQuit(false);
+        e.preventDefault();
+        sendToWindow(mainWindowInfo.mainWindow, 'attemptedClose');
+        closeAttempts++;
+        setTimeout(() => {
+          closeAttempts = 0;
+        }, 10000);
+      }
+    });
+
+    mainWindowInfo.mainWindow.on('closed', () => {
+      mainWindowInfo.mainWindow = null;
+    });
+
+    createMediaWindow();
+  } finally {
+    isCreatingMainWindow = false;
+  }
+}
+
+export function focusMainWindow() {
+  const mainWindow = getExistingMainWindow();
+
+  if (!mainWindow) return false;
+
+  if (mainWindow.isMinimized()) mainWindow.restore();
+  mainWindow.show();
+  mainWindow.focus();
+
+  return true;
+}
+
+const getExistingMainWindow = () => {
   if (mainWindowInfo.mainWindow && !mainWindowInfo.mainWindow.isDestroyed()) {
-    mainWindowInfo.mainWindow.show();
-    return;
+    return mainWindowInfo.mainWindow;
   }
 
-  // Create the browser window
-  mainWindowInfo.mainWindow = createWindow('main');
-
-  mainWindowInfo.mainWindow.on('move', moveMediaWindowThrottled);
-  if (PLATFORM !== 'darwin')
-    mainWindowInfo.mainWindow.on('moved', moveMediaWindowThrottled); // On macOS, the 'moved' event is just an alias for 'move'
-
-  mainWindowInfo.mainWindow.on('close', (e) => {
-    if (
-      mainWindowInfo.mainWindow &&
-      (authorizedClose.authorized || closeAttempts > 2)
-    ) {
-      cancelAllDownloads();
-      closeOtherWindows(mainWindowInfo.mainWindow);
-    } else {
-      setShouldQuit(false);
-      e.preventDefault();
-      sendToWindow(mainWindowInfo.mainWindow, 'attemptedClose');
-      closeAttempts++;
-      setTimeout(() => {
-        closeAttempts = 0;
-      }, 10000);
-    }
+  const existingWindow = BrowserWindow.getAllWindows().find((window) => {
+    return !window.isDestroyed() && window.getTitle() === PRODUCT_NAME;
   });
 
-  mainWindowInfo.mainWindow.on('closed', () => {
-    mainWindowInfo.mainWindow = null;
-  });
+  if (existingWindow) {
+    mainWindowInfo.mainWindow = existingWindow;
+  }
 
-  createMediaWindow();
-}
+  return existingWindow ?? null;
+};
 
 /**
  * Toggles the authorizedClose state


### PR DESCRIPTION
### Motivation
- On macOS an app auto-started at login could be running already, and a subsequent manual launch (Dock or Applications folder) attempted to create a second main window, producing duplicate-window behavior. 
- The change makes the activation/second-instance paths idempotent so relaunch/focus requests reuse any existing main window instead of creating another one.

### Description
- Added a reusable main-window discovery helper and `focusMainWindow` function that finds an existing window by title, restores/minimizes as needed, shows and focuses it, and updates the `mainWindowInfo` reference. 
- Added a creation guard (`isCreatingMainWindow`) and changed `createMainWindow` to call `focusMainWindow()` first and skip creating a new window when appropriate. 
- Updated `second-instance` and `activate` handlers to call `focusMainWindow()` and only fall back to `createMainWindow` when no reusable window is found. 
- Added regression tests (`src-electron/main/__tests__/window-main.test.ts`) covering reuse of an existing main window and restoring a minimized main window.

### Testing
- Ran unit tests with `yarn vitest --project electron src-electron/main/__tests__/window-main.test.ts src-electron/main/__tests__/window-media.test.ts`, and the targeted tests passed (2 test files, 7 tests). 
- Ran lint checks with `yarn eslint -c ./eslint.config.js 'src-electron/electron-main.ts' 'src-electron/main/window/window-main.ts' 'src-electron/main/__tests__/window-main.test.ts'`, and the checked files passed linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be09c4c2948331b268d92874983022)