### PR TITLE
Keep auto-export MP4 conversions out of watched media (fix duplicated UI items)

### DIFF
--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -55,7 +55,8 @@ const electronApi: ElectronApi = {
   closeWebsiteWindow,
   convertHeic,
   convertPdfToImages,
-  createVideoFromNonVideo: (f, fP) => invoke('createVideoFromNonVideo', f, fP),
+  createVideoFromNonVideo: (f, fP, oD) =>
+    invoke('createVideoFromNonVideo', f, fP, oD),
   downloadFile: (u, sD, dF, lP) => invoke('downloadFile', u, sD, dF, lP),
   executeQuery,
   fileUrlToPath,

--- a/src-electron/main/__tests__/ffmpeg.test.ts
+++ b/src-electron/main/__tests__/ffmpeg.test.ts
@@ -57,6 +57,24 @@ describe('ffmpeg.createVideoFromNonVideo', () => {
     expect(out.endsWith('.mp4')).toBe(true);
   });
 
+  it('writes converted files outside the source folder when outputDir is provided', async () => {
+    const { pathExists } = await import('fs-extra/esm');
+    const pathExistsMock = pathExists as unknown as Mock<
+      (p: string) => Promise<boolean>
+    >;
+    pathExistsMock.mockResolvedValue(true);
+
+    const out = await createVideoFromNonVideo(
+      '/tmp/source/a.jpg',
+      '/bin/ffmpeg',
+      '/tmp/cache',
+    );
+
+    expect(out.startsWith('/tmp/cache/')).toBe(true);
+    expect(out).not.toBe('/tmp/source/a.mp4');
+    expect(out.endsWith('.mp4')).toBe(true);
+  });
+
   it('converts image to mp4 - missing dimensions throws', async () => {
     const { pathExists } = await import('fs-extra/esm');
     const pathExistsMock = pathExists as unknown as Mock<

--- a/src-electron/main/ffmpeg.ts
+++ b/src-electron/main/ffmpeg.ts
@@ -1,5 +1,7 @@
 import { pathExists } from 'fs-extra/esm';
+import { createHash } from 'node:crypto';
 import { stat } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
 import { FULL_HD } from 'src/constants/media';
 import upath from 'upath';
 
@@ -120,12 +122,21 @@ const getMaxHeight = (dimensions: {
 export const createVideoFromNonVideo = async (
   originalFile: string,
   ffmpegPath: string,
+  outputDir?: string,
 ): Promise<string> => {
   const existingPromise = conversionQueue.get(originalFile);
   if (existingPromise) return existingPromise;
 
   const conversionPromise = (async (): Promise<string> => {
-    const convertedFilePath = changeExt(originalFile, '.mp4');
+    const convertedFilePath = outputDir
+      ? join(
+          outputDir,
+          `${basename(originalFile, extname(originalFile))}-${createHash('sha1')
+            .update(originalFile)
+            .digest('hex')
+            .slice(0, 8)}.mp4`,
+        )
+      : changeExt(originalFile, '.mp4');
 
     const canReuse = await shouldUseExistingConversion(
       originalFile,

--- a/src-electron/main/ipc.ts
+++ b/src-electron/main/ipc.ts
@@ -314,8 +314,8 @@ handleIpcInvoke(
 
 handleIpcInvoke(
   'createVideoFromNonVideo',
-  async (_e, path: string, ffmpegPath: string) =>
-    createVideoFromNonVideo(path, ffmpegPath),
+  async (_e, path: string, ffmpegPath: string, outputDir?: string) =>
+    createVideoFromNonVideo(path, ffmpegPath, outputDir),
 );
 
 handleIpcInvoke(

--- a/src/helpers/export-media.ts
+++ b/src/helpers/export-media.ts
@@ -12,7 +12,7 @@ import { isCoWeek, isMeetingDay } from 'src/helpers/date';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { setupFFmpeg } from 'src/helpers/fs';
 import { datesAreSame, formatDate, getSpecificWeekday } from 'src/utils/date';
-import { trimFilepathAsNeeded } from 'src/utils/fs';
+import { getTempPath, trimFilepathAsNeeded } from 'src/utils/fs';
 import { pad } from 'src/utils/general';
 import { isJwPlaylist, isVideo } from 'src/utils/media';
 import { useCurrentStateStore } from 'stores/current-state';
@@ -412,7 +412,11 @@ const convertIfNeeded = async (
 
   try {
     const ffmpegPath = await setupFFmpeg();
-    return await createVideoFromNonVideo(sourceFilePath, ffmpegPath);
+    return await createVideoFromNonVideo(
+      sourceFilePath,
+      ffmpegPath,
+      await getTempPath(),
+    );
   } catch (error) {
     errorCatcher(error);
     return null;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -58,6 +58,7 @@ export interface ElectronApi {
   createVideoFromNonVideo: (
     originalFile: string,
     ffmpegPath: string,
+    outputDir?: string,
   ) => Promise<string>;
   downloadFile: (
     url: string,


### PR DESCRIPTION
### Motivation
- When `Enable auto-export` + `Convert exported files to MP4` were used, converted MP4s were written beside the source files and picked up by the folder watcher, producing duplicated items in the UI (issue #6827).

### Description
- Make `createVideoFromNonVideo` accept an optional `outputDir` and generate a hashed MP4 filename in that directory instead of writing next to the source file. (`src-electron/main/ffmpeg.ts`)
- Wire the optional `outputDir` through the Electron boundary via `ipc` and preload: updated `src-electron/main/ipc.ts`, `src-electron/electron-preload.ts`, and `src/types/electron.d.ts`.
- Change the auto-export conversion path to use the app temp cache by passing `await getTempPath()` to `createVideoFromNonVideo` during export. (`src/helpers/export-media.ts`)
- Add an Electron unit test verifying converted files are written to a provided `outputDir`. (`src-electron/main/__tests__/ffmpeg.test.ts`)

### Testing
- Ran `yarn vitest --project electron src-electron/main/__tests__/ffmpeg.test.ts` and the test suite passed. 
- Ran `yarn eslint -c ./eslint.config.js` on the modified files and linting completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be8197c5048331805ddb3321a3fe8f)