### PR TITLE
Improve meeting timer robustness and display placement

### DIFF
--- a/src-electron/main/screen.ts
+++ b/src-electron/main/screen.ts
@@ -7,7 +7,10 @@ import {
   mediaWindow,
   moveMediaWindow,
 } from 'src-electron/main/window/window-media';
-import { moveTimerWindow } from 'src-electron/main/window/window-timer';
+import {
+  moveTimerWindow,
+  timerWindow,
+} from 'src-electron/main/window/window-timer';
 
 export const initScreenListeners = () => {
   app.on('ready', () => {
@@ -71,6 +74,21 @@ export const getAllScreens = (): Display[] => {
     } catch (e) {
       captureElectronError(e, {
         contexts: { fn: { name: 'getAllScreens', window: 'mediaWindow' } },
+      });
+    }
+  }
+
+  if (timerWindow) {
+    try {
+      const timerWindowScreen = displays.find(
+        (display) =>
+          timerWindow &&
+          display.id === screen.getDisplayMatching(timerWindow.getBounds()).id,
+      );
+      if (timerWindowScreen) timerWindowScreen.timerWindow = true;
+    } catch (e) {
+      captureElectronError(e, {
+        contexts: { fn: { name: 'getAllScreens', window: 'timerWindow' } },
       });
     }
   }

--- a/src-electron/main/window/window-base.ts
+++ b/src-electron/main/window/window-base.ts
@@ -90,7 +90,12 @@ export function createWindow(
 
   // Show the window when it's ready
   win.on('ready-to-show', () => {
-    if (name !== 'media') win.show();
+    if (name === 'media') return;
+    if (name === 'timer') {
+      win.showInactive();
+      return;
+    }
+    win.show();
   });
 
   // Hide the menu bar

--- a/src-electron/main/window/window-timer.ts
+++ b/src-electron/main/window/window-timer.ts
@@ -14,7 +14,7 @@ export let timerWindow: BrowserWindow | null = null;
 export function createTimerWindow() {
   // If the window is already open, just focus it
   if (timerWindow && !timerWindow.isDestroyed()) {
-    timerWindow.show();
+    timerWindow.showInactive();
     return;
   }
 
@@ -22,6 +22,7 @@ export function createTimerWindow() {
   timerWindow = createWindow('timer', {
     alwaysOnTop: false,
     backgroundColor: 'black',
+    focusable: true,
     frame: false,
     height: HD_RESOLUTION[1],
     icon: getIconPath('media-player'), // TODO: change icon
@@ -32,6 +33,10 @@ export function createTimerWindow() {
     thickFrame: false,
     title: 'Timer - M³',
     width: HD_RESOLUTION[0],
+  });
+
+  timerWindow.once('ready-to-show', () => {
+    timerWindow?.showInactive();
   });
 
   // For timer, maybe no aspect ratio, or 16/9 as well? Let's keep for now.
@@ -384,6 +389,7 @@ const setTimerWindowPosition = (displayNr?: number, fullscreen = false) => {
 
     if (fullscreen) {
       console.log('🔍 [setTimerWindowPosition] Going fullscreen');
+      timerWindow.setBounds(targetScreenBounds);
       timerWindow.setFullScreen(true);
       try {
         saveTimerWindowPrefs(targetDisplay.bounds);
@@ -429,13 +435,15 @@ const setTimerWindowPosition = (displayNr?: number, fullscreen = false) => {
 
       timerWindow.setFullScreen(false);
       timerWindow.setBounds(bounds);
+      saveTimerWindowPrefs(targetDisplay.bounds);
     }
 
     // Bring timer window to front if it's visible
     if (timerWindow.isVisible()) {
-      console.log('🔍 [setTimerWindowPosition] Bringing timer window to front');
-      timerWindow.focus();
-      timerWindow.show();
+      console.log(
+        '🔍 [setTimerWindowPosition] Refreshing visible timer window without stealing focus',
+      );
+      timerWindow.showInactive();
     }
 
     console.log('🔍 [setTimerWindowPosition] END - All changes queued');

--- a/src/components/dialog/DialogTimerPopup.vue
+++ b/src/components/dialog/DialogTimerPopup.vue
@@ -66,7 +66,7 @@
       <q-separator class="bg-accent-200 q-mb-md" />
 
       <template
-        v-if="!timerPreferences.preferWindowed && screenList?.length > 2"
+        v-if="!timerPreferences.preferWindowed && screenList?.length > 1"
       >
         <q-separator class="bg-accent-200 q-mb-md" />
         <div class="card-section-title row q-px-md">
@@ -110,9 +110,18 @@
                     'calc(' +
                     (screenRects[index]?.height ?? 0) +
                     '% - (var(--screen-gap) * 2))',
+                  borderRadius: '6px',
                 }"
+                unelevated
+                @click="
+                  () => {
+                    if (screen.mainWindow) return;
+                    timerPreferences.preferredScreenNumber = index;
+                    moveTimerWindow(index, !timerPreferences.preferWindowed);
+                  }
+                "
               >
-                <q-tooltip v-if="screen.mainWindow">
+                <q-tooltip v-if="screen.mainWindow" :delay="1000">
                   {{ t('main-window-is-on-this-screen') }}
                 </q-tooltip>
                 <q-icon
@@ -153,12 +162,7 @@
       <!-- Meeting Part Selection (only on meeting days) -->
       <template v-if="isMeetingDay(selectedDateObject?.date)">
         <template v-if="isMwMeetingDay(selectedDateObject?.date)">
-          <template
-            v-if="
-              timerMode === 'countdown' &&
-              isMwMeetingDay(selectedDateObject?.date)
-            "
-          >
+          <template v-if="timerMode === 'countdown'">
             <q-separator class="bg-accent-200 q-mb-md" />
             <div class="card-section-title row q-px-md">
               {{ t('ayfm') }}
@@ -221,25 +225,30 @@
               </div>
             </template>
           </template>
-          <template v-else-if="isWeMeetingDay(selectedDateObject?.date)">
-            <div class="row q-px-md q-py-sm">
-              {{ t('adapt-wt-duration-dynamically') }}
-            </div>
-            <div class="row q-px-md q-py-sm">
-              {{ t('wt-custom-end-time') }}
-            </div>
-            <div class="row q-px-md q-pb-sm">
-              <q-input
-                v-model="wtCustomEndTime"
-                class="full-width"
-                :disable="timerRunning"
-                filled
-                :label="t('end-time')"
-                mask="##:##"
-                :rules="wtEndTimeRules"
-              />
-            </div>
-          </template>
+        </template>
+        <template
+          v-else-if="
+            timerMode === 'countdown' &&
+            isWeMeetingDay(selectedDateObject?.date)
+          "
+        >
+          <div class="row q-px-md q-py-sm">
+            {{ t('adapt-wt-duration-dynamically') }}
+          </div>
+          <div class="row q-px-md q-py-sm">
+            {{ t('wt-custom-end-time') }}
+          </div>
+          <div class="row q-px-md q-pb-sm">
+            <q-input
+              v-model="wtCustomEndTime"
+              class="full-width"
+              :disable="timerRunning"
+              filled
+              :label="t('end-time')"
+              mask="##:##"
+              :rules="wtEndTimeRules"
+            />
+          </div>
         </template>
       </template>
       <q-separator class="bg-accent-200 q-mb-md" />
@@ -470,6 +479,7 @@ import {
   isMwMeetingDay,
   isWeMeetingDay,
 } from 'src/helpers/date';
+import { errorCatcher } from 'src/helpers/error-catcher';
 import { useAppSettingsStore } from 'src/stores/app-settings';
 import { useCurrentStateStore } from 'stores/current-state';
 import { computed, ref, useTemplateRef, watch } from 'vue';
@@ -529,6 +539,41 @@ const editDialogOpen = ref(false);
 const editPart = ref<null | { label: string; value: MeetingPart }>(null);
 const editDuration = ref(0);
 
+const rebalancePartDurations = (
+  prefix: 'ayfm' | 'lac',
+  editedPartValue: MeetingPart,
+  totalMinutes: number,
+  totalParts: number,
+) => {
+  const splitEditedPart = editedPartValue.split('-');
+  const partIndexString = splitEditedPart[1];
+  const partIndex = parseInt(partIndexString || '0');
+
+  let consumedMinutes = 0;
+  for (let i = 1; i <= partIndex; i++) {
+    consumedMinutes +=
+      partDurations.value[`${prefix}-${i}` as MeetingPart] || 0;
+  }
+
+  const remainingMinutes = totalMinutes - consumedMinutes;
+  const remainingParts = totalParts - partIndex;
+
+  if (remainingParts > 0) {
+    const baseDuration = Math.floor(remainingMinutes / remainingParts);
+    let remainder = remainingMinutes % remainingParts;
+
+    for (let i = partIndex + 1; i <= totalParts; i++) {
+      partDurations.value[`${prefix}-${i}` as MeetingPart] =
+        baseDuration + (remainder > 0 ? 1 : 0);
+      if (remainder > 0) {
+        remainder--;
+      }
+    }
+  } else if (remainingParts === 0 && consumedMinutes !== totalMinutes) {
+    partDurations.value[editedPartValue] += totalMinutes - consumedMinutes;
+  }
+};
+
 // Open edit dialog for a part
 const openEditDialog = (part: { label: string; value: MeetingPart }) => {
   editPart.value = part;
@@ -546,66 +591,15 @@ const saveEdit = () => {
   // Update the edited part's duration
   partDurations.value[editedPartValue] = newDuration;
 
-  // Check if it's an AYFM or LAC part
-  const splitEditedPart = editedPartValue.split('-');
-  const partIndexString = splitEditedPart[1];
-  const partIndex = parseInt(partIndexString || '0');
   if (editedPartValue.startsWith('ayfm-')) {
-    const totalAyfmParts = ayfmPartsCount.value;
-    const totalAyfmMinutes = 15 - totalAyfmParts; // 15 minutes total, minus 1 minute for counsel per part
-
-    let consumedMinutes = 0;
-    for (let i = 1; i <= partIndex; i++) {
-      consumedMinutes += partDurations.value[`ayfm-${i}` as MeetingPart] || 0;
-    }
-
-    const remainingMinutes = totalAyfmMinutes - consumedMinutes;
-    const remainingParts = totalAyfmParts - partIndex;
-
-    if (remainingParts > 0) {
-      const baseDuration = Math.floor(remainingMinutes / remainingParts);
-      let remainder = remainingMinutes % remainingParts;
-
-      for (let i = partIndex + 1; i <= totalAyfmParts; i++) {
-        partDurations.value[`ayfm-${i}` as MeetingPart] =
-          baseDuration + (remainder > 0 ? 1 : 0);
-        if (remainder > 0) {
-          remainder--;
-        }
-      }
-    } else if (remainingParts === 0 && consumedMinutes !== totalAyfmMinutes) {
-      // If it's the last part and total time is off, adjust the last part
-      partDurations.value[editedPartValue] =
-        newDuration + (totalAyfmMinutes - consumedMinutes);
-    }
+    rebalancePartDurations(
+      'ayfm',
+      editedPartValue,
+      15 - ayfmPartsCount.value,
+      ayfmPartsCount.value,
+    );
   } else if (editedPartValue.startsWith('lac-')) {
-    const totalLacParts = lacPartsCount.value;
-    const totalLacMinutes = 15; // 15 minutes total
-
-    let consumedMinutes = 0;
-    for (let i = 1; i <= partIndex; i++) {
-      consumedMinutes += partDurations.value[`lac-${i}` as MeetingPart] || 0;
-    }
-
-    const remainingMinutes = totalLacMinutes - consumedMinutes;
-    const remainingParts = totalLacParts - partIndex;
-
-    if (remainingParts > 0) {
-      const baseDuration = Math.floor(remainingMinutes / remainingParts);
-      let remainder = remainingMinutes % remainingParts;
-
-      for (let i = partIndex + 1; i <= totalLacParts; i++) {
-        partDurations.value[`lac-${i}` as MeetingPart] =
-          baseDuration + (remainder > 0 ? 1 : 0);
-        if (remainder > 0) {
-          remainder--;
-        }
-      }
-    } else if (remainingParts === 0 && consumedMinutes !== totalLacMinutes) {
-      // If it's the last part and total time is off, adjust the last part
-      partDurations.value[editedPartValue] =
-        newDuration + (totalLacMinutes - consumedMinutes);
-    }
+    rebalancePartDurations('lac', editedPartValue, 15, lacPartsCount.value);
   }
 
   editDialogOpen.value = false;
@@ -631,8 +625,8 @@ const exportPdfReport = async () => {
   doc.text(`Meeting Report - ${meetingDate}`, 14, 22);
 
   const tableColumn = [
-    'Part',
-    'Start (hh:mm:ss)',
+    t('meeting-part'),
+    `${t('start-time')} (hh:mm:ss)`,
     'End (hh:mm:ss)',
     'Duration (mm:ss)',
   ];
@@ -643,8 +637,8 @@ const exportPdfReport = async () => {
     const timings = partTimings.value[partValue];
     const duration = partDurations.value[partValue];
 
-    const formattedStartTime = getTimeString(timings?.startTime);
-    const formattedEndTime = getTimeString(timings?.endTime);
+    const formattedStartTime = getTimeString(timings?.startTime, true);
+    const formattedEndTime = getTimeString(timings?.endTime, true);
     const formattedDuration = getDuration(timings, duration);
 
     tableRows.push([
@@ -685,7 +679,9 @@ const fetchScreens = async () => {
   try {
     screenList.value = await getAllScreens();
   } catch (error) {
-    console.error(error);
+    void errorCatcher(error, {
+      contexts: { timer: { action: 'fetchScreens' } },
+    });
   }
 };
 
@@ -744,8 +740,12 @@ const screenRects = computed(() => {
 
 // Selected when timer window is on this screen and it's not the app's main window
 const isTimerScreenSelected = (index: number, screen: Display) => {
-  void index; // index kept for potential future preference logic
-  return !!screen.timerWindow && !screen.mainWindow;
+  return (
+    (!!screen.timerWindow && !screen.mainWindow) ||
+    (!timerWindowVisible.value &&
+      timerPreferences.value.preferredScreenNumber === index &&
+      !screen.mainWindow)
+  );
 };
 
 // UI update handler

--- a/src/composables/useTimer.ts
+++ b/src/composables/useTimer.ts
@@ -13,6 +13,7 @@ import {
   isMwMeetingDay,
   isWeMeetingDay,
 } from 'src/helpers/date';
+import { errorCatcher } from 'src/helpers/error-catcher';
 import { useCurrentStateStore } from 'stores/current-state';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -30,6 +31,25 @@ const useTimer = () => {
   const cbsCustomEndTime = ref('');
   const ayfmPartsCount = ref<number>(1);
   const lacPartsCount = ref<number>(1);
+
+  const distributePartDurations = (
+    prefix: 'ayfm' | 'lac',
+    count: number,
+    totalMinutes: number,
+  ) => {
+    const maxParts = prefix === 'ayfm' ? 5 : 3;
+    const base = Math.floor(totalMinutes / count);
+    const remainder = totalMinutes % count;
+
+    for (let i = 1; i <= maxParts; i++) {
+      const key = `${prefix}-${i}` as MeetingPart;
+      if (i <= count) {
+        partDurations.value[key] = base + (i <= remainder ? 1 : 0);
+      } else {
+        partDurations.value[key] = 0;
+      }
+    }
+  };
 
   const getTimeString = (timestamp: null | number, seconds = false): string => {
     try {
@@ -76,32 +96,12 @@ const useTimer = () => {
 
   // Watch AYFM parts count to adjust durations
   watch(ayfmPartsCount, (newCount) => {
-    const totalMinutes = 15 - newCount; // 15 minutes total, minus number of parts for 1 min of counsel each
-    const base = Math.floor(totalMinutes / newCount);
-    const remainder = totalMinutes % newCount;
-    for (let i = 1; i <= 5; i++) {
-      if (i <= newCount) {
-        const dur = base + (i <= remainder ? 1 : 0);
-        partDurations.value[`ayfm-${i}` as MeetingPart] = dur;
-      } else {
-        partDurations.value[`ayfm-${i}` as MeetingPart] = 0;
-      }
-    }
+    distributePartDurations('ayfm', newCount, 15 - newCount);
   });
 
   // Watch LAC parts count to adjust durations
   watch(lacPartsCount, (newCount) => {
-    const totalMinutes = 15;
-    const base = Math.floor(totalMinutes / newCount);
-    const remainder = totalMinutes % newCount;
-    for (let i = 1; i <= 3; i++) {
-      if (i <= newCount) {
-        const dur = base + (i <= remainder ? 1 : 0);
-        partDurations.value[`lac-${i}` as MeetingPart] = dur;
-      } else {
-        partDurations.value[`lac-${i}` as MeetingPart] = 0;
-      }
-    }
+    distributePartDurations('lac', newCount, 15);
   });
 
   const meetingPartsOptions = computed<
@@ -258,7 +258,7 @@ const useTimer = () => {
     currentState.setTimerWindowVisible(visible);
     if (visible) {
       // Broadcast initial timer settings
-      postTimerData({
+      safePostTimerData({
         aheadBehindMinutes: calculateAheadBehindMinutes(),
         enableMeetingCountdown: currentSettings.value?.enableMeetingCountdown,
         meetingCountdownMinutes: currentSettings.value?.meetingCountdownMinutes,
@@ -424,7 +424,7 @@ const useTimer = () => {
   const stopTimer = () => {
     pauseInterval();
     // Immediately send cleared timer data to external window
-    postTimerData({
+    safePostTimerData({
       mode: timerMode.value,
       paused: false,
       running: false,
@@ -507,6 +507,16 @@ const useTimer = () => {
     name: 'timer-display-data',
   });
 
+  const safePostTimerData = (timerData: TimerData) => {
+    try {
+      postTimerData(timerData);
+    } catch (error) {
+      void errorCatcher(error, {
+        contexts: { timer: { action: 'postTimerData' } },
+      });
+    }
+  };
+
   const updateTimerWindow = () => {
     // Send timer data to the timer window via broadcast channel
     const timerData = {
@@ -526,7 +536,7 @@ const useTimer = () => {
       weStartTime: currentSettings.value?.weStartTime,
     };
 
-    postTimerData(timerData);
+    safePostTimerData(timerData);
   };
 
   // Calculate ahead/behind minutes

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -176,7 +176,7 @@
   "enableSubtitles": "Enable subtitles",
   "enableSubtitles-explain": "Enable subtitles by default for all videos.",
   "enableTimerDisplay": "Enable meeting timer display",
-  "enableTimerDisplay-explain": "Enable this to display a timer in a separate window that can be used to show timing information to speakers.",
+  "enableTimerDisplay-explain": "Enable this to display a timer in a separate window for speaker timing. This should only be enabled if approved by the local elders.",
   "end-time": "End time (hh:mm)",
   "enter-a-key-combination": "Enter a key combination",
   "enter-a-key-combination-now-using-your-keyboard": "Enter a key combination now using your keyboard.",

--- a/src/pages/TimerPage.vue
+++ b/src/pages/TimerPage.vue
@@ -153,7 +153,7 @@ const getTodayMeetingInfo = (today: number, data: TimerData) => {
 const parseTime = (timeStr: string, base: Date) => {
   const [h, m] = timeStr.split(':').map(Number);
   const d = new Date(base);
-  if (!h || !m) return d;
+  if (Number.isNaN(h) || Number.isNaN(m)) return d;
   d.setHours(h, m, 0, 0);
   return d;
 };


### PR DESCRIPTION
### Motivation
- Make the new meeting timer feature reliable and non-disruptive to media playback by isolating timer window behavior and hardening timer data flows. 
- Provide a simple, realistic screen-selection UX and remember timer display preferences so the timer can be placed on the intended monitor without stealing focus. 
- Fix adaptive countdown branches for weekend (WT) vs midweek (MW) meeting settings and make part duration editing easier and more predictable. 

### Description
- Use a safe wrapper when broadcasting timer data to the external timer window to prevent timer errors from throwing into the UI, and add `errorCatcher` usage for screen fetch and broadcast failures. 
- Centralize AYFM/LAC duration distribution and rebalance logic so changing part counts or editing a part updates remaining parts consistently. 
- Fix template logic so adaptive WT/CBS end-time controls render for the correct meeting-day branches and improve PDF export to include hh:mm:ss for start/end times. 
- Make the display-map selectable in the timer popup and mark the timer window in Electron screen metadata by detecting `timerWindow` in `getAllScreens`. 
- Make the timer window non-disruptive by showing/updating it with `showInactive()` (avoid stealing focus), persist selected display geometry on both fullscreen and windowed changes, and save timer window prefs when repositioning. 
- Small robustness fixes: safer `HH:mm` parsing in the timer page, minor UI/layout fixes for the display map, and other defensive checks. 

### Testing
- Ran lint/auto-fix on the changed files with `yarn eslint -c ./eslint.config.js src/components/dialog/DialogTimerPopup.vue src/composables/useTimer.ts src/pages/TimerPage.vue src-electron/main/window/window-timer.ts src-electron/main/screen.ts src-electron/main/window/window-base.ts` and the targeted checks completed successfully. 
- Ran the repository pre-commit formatting and auto-fix steps (Prettier + ESLint auto-fix) during commit preparation. 
- Ran `yarn lint` for the whole repo which reported unrelated, pre-existing TypeScript issues elsewhere in the codebase (these errors are not caused by the timer changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c163e91dc88331ab0f48cccfa9aeb7)