### PR TITLE
Use getJwIconFromKeyword in timer and add JW icon keywords/type

### DIFF
--- a/src/composables/useTimer.ts
+++ b/src/composables/useTimer.ts
@@ -6,7 +6,6 @@ import {
   watchImmediate,
 } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
-import { jwIcons } from 'src/constants/jw-icons';
 import {
   isCoWeek,
   isMeetingDay,
@@ -14,6 +13,7 @@ import {
   isWeMeetingDay,
 } from 'src/helpers/date';
 import { errorCatcher } from 'src/helpers/error-catcher';
+import { getJwIconFromKeyword } from 'src/helpers/fonts';
 import { useCurrentStateStore } from 'stores/current-state';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -121,12 +121,12 @@ const useTimer = () => {
         warning?: boolean;
       }[] = [
         {
-          icon: jwIcons['pt'],
+          icon: getJwIconFromKeyword('public-talk'),
           label: t('public-talk'),
           value: 'public-talk',
         },
         {
-          icon: jwIcons['wt'],
+          icon: getJwIconFromKeyword('wt'),
           label: t('wt'),
           value: 'wt',
         },
@@ -134,7 +134,7 @@ const useTimer = () => {
 
       if (isCoWeek(date)) {
         options.push({
-          icon: jwIcons['circuit-overseer'],
+          icon: getJwIconFromKeyword('co-final-talk'),
           label: t('co-final-talk'),
           value: 'co-final-talk',
         });
@@ -150,22 +150,22 @@ const useTimer = () => {
         warning?: boolean;
       }[] = [
         {
-          icon: jwIcons['introduction'],
+          icon: getJwIconFromKeyword('introduction'),
           label: t('introduction'),
           value: 'introduction',
         },
         {
-          icon: jwIcons['tgw'],
+          icon: getJwIconFromKeyword('treasures'),
           label: t('treasures-talk'),
           value: 'treasures',
         },
         {
-          icon: jwIcons['gems'],
+          icon: getJwIconFromKeyword('gems'),
           label: t('gems'),
           value: 'gems',
         },
         {
-          icon: jwIcons['bible-reading'],
+          icon: getJwIconFromKeyword('bible-reading'),
           label: t('bible-reading'),
           value: 'bible-reading',
         },
@@ -180,7 +180,7 @@ const useTimer = () => {
         const warning = totalDuration !== 15 - ayfmPartsCount.value;
         const dur = partDurations.value[`ayfm-${i}` as MeetingPart] || 14;
         options.push({
-          icon: jwIcons['ayfm-part'],
+          icon: getJwIconFromKeyword('ayfm-part'),
           label: t('ayfm-part', { duration: dur, part: i }),
           value: `ayfm-${i}` as MeetingPart,
           warning,
@@ -195,7 +195,7 @@ const useTimer = () => {
         const warning = totalDuration !== 15;
         const dur = partDurations.value[`lac-${i}` as MeetingPart] || 15;
         options.push({
-          icon: jwIcons['lac-part'],
+          icon: getJwIconFromKeyword('lac-part'),
           label: t('lac-part', { duration: dur, part: i }),
           value: `lac-${i}` as MeetingPart,
           warning,
@@ -203,19 +203,19 @@ const useTimer = () => {
       }
       if (isCo) {
         options.push({
-          icon: jwIcons['circuit-overseer'],
+          icon: getJwIconFromKeyword('co-service-talk'),
           label: t('co-service-talk'),
           value: 'co-service-talk',
         });
       } else {
         options.push({
-          icon: jwIcons['cbs'],
+          icon: getJwIconFromKeyword('cbs'),
           label: t('cbs'),
           value: 'cbs',
         });
       }
       options.push({
-        icon: jwIcons['concluding-comments'],
+        icon: getJwIconFromKeyword('concluding-comments'),
         label: t('concluding-comments'),
         value: 'concluding-comments',
       });

--- a/src/constants/jw-icons.ts
+++ b/src/constants/jw-icons.ts
@@ -22,17 +22,28 @@ export const fallbackJwIconsGlyphMap: Record<string, string> = {
 
 export const keywordToJwIconMapping: Record<string, string | undefined> = {
   ayfm: 'wheat',
+  'ayfm-part': 'wheat',
+  'bible-reading': 'meeting-workbook-stack',
   'brochures-and-booklets': 'brochure-stack',
+  cbs: 'sheep',
   'circuit-overseer': 'speaker',
+  'co-final-talk': 'speaker',
+  'co-service-talk': 'speaker',
+  'concluding-comments': 'speaker',
   g: 'awake-exclamation-mark',
+  gems: 'awake-exclamation-mark',
+  introduction: 'speaker',
   lac: 'sheep',
+  'lac-part': 'sheep',
   magazines: 'magazine-stack',
   'meeting-workbooks': 'meeting-workbook-stack',
   memorial: 'wine-bread',
   programs: 'arena',
   pt: 'speaker',
+  'public-talk': 'speaker',
   tgw: 'gem',
   'tracts-and-invitations': 'tract-stack',
+  treasures: 'gem',
   'tv-logo': 'jw-square',
   w: 'watchtower',
   'welcome-video': 'video',
@@ -40,3 +51,5 @@ export const keywordToJwIconMapping: Record<string, string | undefined> = {
   ws: 'watchtower-square',
   wt: 'watchtower',
 };
+
+export type JwIconKeyword = keyof typeof keywordToJwIconMapping;

--- a/src/helpers/media-sections.ts
+++ b/src/helpers/media-sections.ts
@@ -1,3 +1,4 @@
+import type { JwIconKeyword } from 'src/constants/jw-icons';
 import type {
   DateInfo,
   MediaItem,
@@ -160,7 +161,7 @@ function getMeetingSectionConfigs(
   }
 
   // Sections that have icons
-  const iconSections: jwIconsKeys[] = [
+  const iconSections: JwIconKeyword[] = [
     'ayfm',
     'lac',
     'tgw',
@@ -169,7 +170,7 @@ function getMeetingSectionConfigs(
     'circuit-overseer',
   ];
 
-  if (iconSections.includes(section as jwIconsKeys)) {
+  if (iconSections.includes(section as JwIconKeyword)) {
     return {
       jwIconKeyword: section,
       uniqueId: section,


### PR DESCRIPTION
### Motivation
- Fix TypeScript errors caused by the removed `jwIcons` export and adapt the code to the current helper-based icon API (`getJwIconFromKeyword`).
- Ensure media section configuration remains type-safe by aligning section icon keywords with the canonical JW icon keyword map.

### Description
- Replaced direct `jwIcons` lookups in `src/composables/useTimer.ts` with `getJwIconFromKeyword(...)` calls for each meeting part keyword so icons resolve via the new helper. 
- Added timer-related mappings to `keywordToJwIconMapping` in `src/constants/jw-icons.ts` (e.g. `ayfm-part`, `lac-part`, `bible-reading`, `cbs`, `co-service-talk`, `co-final-talk`, `concluding-comments`, `public-talk`, `treasures`, `gems`, `introduction`) and exported a `JwIconKeyword` type. 
- Replaced the stale `jwIconsKeys` usage in `src/helpers/media-sections.ts` with the new `JwIconKeyword` type and adjusted imports accordingly. 
- Performed small import/order and lint fixes to satisfy the project linter.

### Testing
- Ran `yarn eslint --fix src/constants/jw-icons.ts src/helpers/media-sections.ts src/composables/useTimer.ts` which completed successfully. 
- Ran `yarn lint` which completed successfully and confirmed no remaining lint errors in the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c18e757fa48331bde4b4ea8425c8ab)