### PR TITLE
Optimize Zoom helper responsiveness and auto-manage meeting integration

### DIFF
--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -124,6 +124,7 @@ const electronApi: ElectronApi = {
   readdir: readDirectory,
   registerShortcut: (n, s) => invoke('registerShortcut', n, s),
   removeListeners: (c) => removeAllIpcListeners(c),
+  restartZoomHelper: () => send('restartZoomHelper'),
   robot,
   sendZoomWindowKeys: (h, k) => invoke('sendZoomWindowKeys', h, k),
   setAutoStartAtLogin: (v) => send('toggleOpenAtLogin', v),

--- a/src-electron/main/ipc.ts
+++ b/src-electron/main/ipc.ts
@@ -82,6 +82,7 @@ import {
 import {
   ensureRequirementsInstalled,
   isPythonInstalled,
+  restartZoomHelper,
   startZoomHelper,
   stopZoomHelper,
 } from 'src-electron/main/zoom-helper-manager';
@@ -306,6 +307,7 @@ handleIpcInvoke('ensureZoomRequirements', async () =>
 );
 handleIpcSend('startZoomHelper', () => startZoomHelper());
 handleIpcSend('stopZoomHelper', () => stopZoomHelper());
+handleIpcSend('restartZoomHelper', () => restartZoomHelper());
 
 handleIpcInvoke(
   'isArchitectureMismatch',
@@ -391,6 +393,9 @@ const getZoomWindows = async (className?: string) => {
   }
 };
 
+const controlsVisibilityChecks = new Map<string, number>();
+const zoomWindowClassByHandle = new Map<number, string>();
+
 handleIpcInvoke(
   'listZoomWindows',
   async (_e, mainOnly = false, className?: string) => {
@@ -401,6 +406,10 @@ handleIpcInvoke(
     if (mainOnly) {
       result = windows.filter((w) => w.main_zoom_window);
     }
+
+    result.forEach((window) => {
+      zoomWindowClassByHandle.set(window.handle, window.class_name);
+    });
 
     return result;
   },
@@ -464,6 +473,23 @@ async function sendZoomWindowKeysInternal(handle: number, keys: string) {
 
 async function showControlsIfHidden(handle: number) {
   try {
+    const now = Date.now();
+    const checkKey = String(handle);
+    const lastCheckedAt = controlsVisibilityChecks.get(checkKey) ?? 0;
+    if (now - lastCheckedAt < 1500) {
+      return;
+    }
+    controlsVisibilityChecks.set(checkKey, now);
+
+    const className = zoomWindowClassByHandle.get(handle);
+    if (
+      className &&
+      className !== 'ConfMultiTabContentWndClass' &&
+      className !== 'ZPMeetingWndClass'
+    ) {
+      return;
+    }
+
     const result = await fetchZoomDialogChildren('ZPControlPanelClass', handle);
 
     if (!result.length) {

--- a/src-electron/main/zoom-helper-manager.ts
+++ b/src-electron/main/zoom-helper-manager.ts
@@ -47,13 +47,20 @@ export async function isPythonInstalled(): Promise<boolean> {
   });
 }
 
+export function restartZoomHelper() {
+  stopZoomHelper();
+  startZoomHelper();
+}
+
 export function startZoomHelper() {
   if (pythonProcess || PLATFORM !== 'win32') return;
 
   const helperPath = getHelperPath('uia_helper.py');
 
   log(`Starting Zoom Helper`, 'zoom', 'info', helperPath);
-  pythonProcess = spawn(getPythonCommand(), [helperPath]);
+  pythonProcess = spawn(getPythonCommand(), [helperPath], {
+    env: { ...process.env, PYTHONUNBUFFERED: '1' },
+  });
 
   pythonProcess.stdout.on('data', (data: Buffer) => {
     const msg = data.toString().trim();

--- a/src/components/dialog/DialogBackgroundMusicPopup.vue
+++ b/src/components/dialog/DialogBackgroundMusicPopup.vue
@@ -112,6 +112,7 @@ import { remainingTimeBeforeMeetingStart } from 'src/helpers/date';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { downloadBackgroundMusic } from 'src/helpers/jw-media';
 import {
+  autoLaunchZoomMeetingIfNeeded,
   automateZoomMeetingSettings,
   automateZoomPostMeetingSettings,
 } from 'src/helpers/zoom';
@@ -287,6 +288,7 @@ whenever(
   () => musicPlaying.value,
   () => {
     musicState.value = 'music.playing';
+    autoLaunchZoomMeetingIfNeeded(timeUntilMeeting.value);
     automateZoomPostMeetingSettings();
   },
 );

--- a/src/components/dialog/DialogZoomMeetingManagerPopup.vue
+++ b/src/components/dialog/DialogZoomMeetingManagerPopup.vue
@@ -88,39 +88,35 @@
 
       <div class="row q-px-md q-pt-md q-gutter-x-sm">
         <q-btn
-          class="col"
-          color="positive"
+          class="col-12"
+          color="primary"
           dense
           no-caps
           outline
-          @click="startZoomHelper"
+          @click="restartZoomHelper"
         >
-          {{ t('start') }}
-        </q-btn>
-        <q-btn
-          class="col"
-          color="negative"
-          dense
-          no-caps
-          outline
-          @click="stopZoomHelper"
-        >
-          {{ t('stop') }}
+          {{ t('restart') }}
         </q-btn>
       </div>
 
       <div v-if="zoomHelperLogs.length" class="row q-px-md q-pt-md">
-        <div class="col-12 text-caption text-weight-medium q-mb-xs">
-          {{ t('logs') }}
-        </div>
-        <div
-          class="col-12 bg-dark text-white q-pa-sm rounded-borders scroll"
-          style="max-height: 200px; font-family: monospace; font-size: 10px"
+        <q-expansion-item
+          v-model="logsExpanded"
+          class="col-12 bg-grey-2 rounded-borders"
+          dense
+          dense-toggle
+          expand-separator
+          :label="t('logs')"
         >
-          <div v-for="(log, index) in zoomHelperLogs" :key="index">
-            {{ log }}
+          <div
+            class="bg-dark text-white q-pa-sm rounded-borders scroll"
+            style="max-height: 200px; font-family: monospace; font-size: 10px"
+          >
+            <div v-for="(logLine, index) in zoomHelperLogs" :key="index">
+              {{ logLine }}
+            </div>
           </div>
-        </div>
+        </q-expansion-item>
       </div>
     </div>
   </q-menu>
@@ -137,7 +133,7 @@ import {
 } from 'src/helpers/zoom';
 import { log } from 'src/shared/vanilla';
 import { useCurrentStateStore } from 'stores/current-state';
-import { computed, ref, useTemplateRef, watch } from 'vue';
+import { computed, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const zoomMeetingManagerPopupRef = useTemplateRef<QMenu>(
@@ -146,7 +142,7 @@ const zoomMeetingManagerPopupRef = useTemplateRef<QMenu>(
 
 const open = defineModel<boolean>({ required: true });
 
-const { launchZoomMeeting, listZoomWindows, startZoomHelper, stopZoomHelper } =
+const { launchZoomMeeting, listZoomWindows, restartZoomHelper } =
   globalThis.electronApi;
 
 const currentState = useCurrentStateStore();
@@ -158,6 +154,8 @@ const meetingId = computed(
 
 const zoomWindows = ref<ZoomUIElement[]>([]);
 const selectedZoomWindow = ref<null | ZoomUIElement>(null);
+const logsExpanded = ref(false);
+let mainWindowPollingInterval: null | ReturnType<typeof setInterval> = null;
 
 const listMainZoomWindows = async () => {
   selectedZoomWindow.value = null;
@@ -166,6 +164,22 @@ const listMainZoomWindows = async () => {
     selectedZoomWindow.value = zoomWindows.value[0];
   }
   log(zoomWindows.value, 'zoom', 'debug', zoomWindows.value);
+};
+
+const syncMainWindowSelection = async () => {
+  const windows = await listZoomWindows(true);
+  zoomWindows.value = windows;
+
+  const selectedHandle = selectedZoomWindow.value?.handle;
+  if (selectedHandle) {
+    const existingWindow = windows.find((w) => w.handle === selectedHandle);
+    if (existingWindow) {
+      selectedZoomWindow.value = existingWindow;
+      return;
+    }
+  }
+
+  selectedZoomWindow.value = windows[0] ?? null;
 };
 
 const { t } = useI18n();
@@ -181,4 +195,29 @@ watch(
     }, 10);
   },
 );
+
+watch(
+  () => open.value,
+  (isOpen) => {
+    if (mainWindowPollingInterval) {
+      clearInterval(mainWindowPollingInterval);
+      mainWindowPollingInterval = null;
+    }
+
+    if (!isOpen) return;
+
+    void syncMainWindowSelection();
+    mainWindowPollingInterval = setInterval(() => {
+      void syncMainWindowSelection();
+    }, 5000);
+  },
+  { immediate: true },
+);
+
+onUnmounted(() => {
+  if (mainWindowPollingInterval) {
+    clearInterval(mainWindowPollingInterval);
+    mainWindowPollingInterval = null;
+  }
+});
 </script>

--- a/src/constants/settings.ts
+++ b/src/constants/settings.ts
@@ -278,6 +278,13 @@ export const settingsDefinitions: SettingsItems = {
     subgroup: 'zoomMeetingManager',
     type: 'text',
   },
+  zoomMeetingManagerAutoLaunchMeeting: {
+    depends: 'zoomMeetingManagerEnable',
+    group: 'integrations',
+    platforms: ['win32'],
+    subgroup: 'zoomMeetingManager',
+    type: 'toggle',
+  },
   zoomMeetingManagerAutomateMeetingAudioSettings: {
     depends: 'zoomMeetingManagerEnable',
     group: 'integrations',
@@ -770,6 +777,7 @@ export const defaultSettings: SettingsValues = {
   zoomAudioUnmutedTitle: null,
   zoomAutoFocusMediaWindow: false,
   zoomEnable: false,
+  zoomMeetingManagerAutoLaunchMeeting: false,
   zoomMeetingManagerAutomateMediaSharing: false,
   zoomMeetingManagerAutomateMeetingAudioSettings: false,
   zoomMeetingManagerAutomatePostMeetingAudioSettings: false,

--- a/src/helpers/zoom.ts
+++ b/src/helpers/zoom.ts
@@ -15,6 +15,7 @@ const {
   getZoomDialogChildren,
   getZoomElementState,
   getZoomElementTitle,
+  launchZoomMeeting,
   listZoomWindows,
 } = globalThis.electronApi;
 
@@ -582,6 +583,34 @@ export const automateZoomPostMeetingSettings = async () => {
       contexts: { fn: { name: 'automateZoomPostMeetingSettings' } },
     });
   }
+};
+
+export const autoLaunchZoomMeetingIfNeeded = async (
+  timeUntilMeetingSeconds?: number,
+) => {
+  const currentState = useCurrentStateStore();
+  const settings = currentState.currentSettings;
+  if (!settings?.zoomMeetingManagerEnable) return;
+  if (!settings.zoomMeetingManagerAutoLaunchMeeting) return;
+
+  const meetingId = settings.zoomMeetingManagerMeetingId?.trim();
+  if (!meetingId) return;
+
+  if (
+    typeof timeUntilMeetingSeconds === 'number' &&
+    timeUntilMeetingSeconds <= 0
+  ) {
+    return;
+  }
+
+  const mainZoomWindow = await getMainZoomWindow();
+  if (mainZoomWindow?.handle) return;
+
+  log('Auto-launching Zoom meeting before meeting start', 'zoom', 'info', {
+    meetingId,
+    timeUntilMeetingSeconds,
+  });
+  launchZoomMeeting(meetingId);
 };
 
 /**

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -669,6 +669,8 @@
   "zoomMeetingManager": "Zoom Meeting Manager",
   "zoomMeetingManagerAutomateMediaSharing": "Automate media sharing",
   "zoomMeetingManagerAutomateMediaSharing-explain": "Automatically share the media window on Zoom when media is shared on TVs.",
+  "zoomMeetingManagerAutoLaunchMeeting": "Auto-launch Zoom meeting before meetings",
+  "zoomMeetingManagerAutoLaunchMeeting-explain": "When background music starts before a meeting, M³ will launch the configured Zoom meeting only if no main Zoom meeting window is found.",
   "zoomMeetingManagerAutomateMeetingAudioSettings": "Automate settings that should be applied during meetings",
   "zoomMeetingManagerAutomateMeetingAudioSettings-explain": "This will get triggered when background music is stopped, a few moments before a meeting starts. It will join computer audio, turn on host video, mute everyone, and disable unmuting microphones.",
   "zoomMeetingManagerAutomatePostMeetingAudioSettings": "Automate settings that should be applied before and after meetings",

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -906,7 +906,12 @@ bcClose.onmessage = (event) => {
 const initListeners = () => {
   onLog(({ ctx, level, msg }) => {
     log(`[main] ${msg}`, ctx as unknown as LogPrefix, level, ctx);
-    if (msg.startsWith('[Zoom Helper]')) {
+    if (
+      msg.startsWith('[Pip]') ||
+      msg.startsWith('[Pip Error]') ||
+      msg.startsWith('[Zoom Helper]') ||
+      msg.startsWith('[Zoom Helper Error]')
+    ) {
       currentState.addZoomHelperLog(msg);
     }
   });

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -233,6 +233,7 @@ export interface ElectronApi {
   ) => Promise<FileItem[]>;
   registerShortcut: (name: keyof SettingsValues, shortcut: string) => void;
   removeListeners: (channel: ElectronIpcListenKey) => void;
+  restartZoomHelper: () => void;
   robot: typeof robot;
   sendZoomWindowKeys: (handle: number, keys: string) => Promise<boolean>;
   setAutoStartAtLogin: (value: boolean) => void;
@@ -325,6 +326,7 @@ export type ElectronIpcSendKey =
   | 'openDiscussion'
   | 'openExternal'
   | 'quitAndInstall'
+  | 'restartZoomHelper'
   | 'setElectronUrlVariables'
   | 'startZoomHelper'
   | 'stopZoomHelper'

--- a/src/types/settings.d.ts
+++ b/src/types/settings.d.ts
@@ -286,6 +286,7 @@ export interface SettingsValues {
   zoomAudioUnmutedTitle: null | string;
   zoomAutoFocusMediaWindow: boolean;
   zoomEnable: boolean;
+  zoomMeetingManagerAutoLaunchMeeting: boolean;
   zoomMeetingManagerAutomateMediaSharing: boolean;
   zoomMeetingManagerAutomateMeetingAudioSettings: boolean;
   zoomMeetingManagerAutomatePostMeetingAudioSettings: boolean;

--- a/uia_helper.py
+++ b/uia_helper.py
@@ -1,11 +1,27 @@
 import json
 import traceback
+from time import monotonic
 
 from pywinauto import Application, Desktop, findwindows
 from flask import Flask, jsonify, request
 from waitress import serve
 
 app = Flask(__name__)
+ZOOM_WINDOW_CLASS_NAMES = {
+    "ConfMultiTabContentWndClass",
+    "WCN_ModelessWnd",
+    "zChangeNameWndClass",
+    "ZGridMultiLevelPopupWndClass",
+    "zJoinAudioWndClass",
+    "ZPFloatToolbarClass",
+    "ZPShareEntranceClass",
+    "ZPMeetingWndClass",
+}
+MAIN_WINDOW_CACHE_TTL_SECONDS = 2
+DESCENDANT_CACHE_TTL_SECONDS = 2
+
+_main_window_cache = {}
+_descendants_cache = {}
 
 
 def get_element_data(element):
@@ -37,6 +53,63 @@ def get_element_data(element):
     return data
 
 
+def _cache_key(win):
+    return f"{win.process_id()}:{win.handle}"
+
+
+def _extract_control_id_from_help(help_text):
+    if not help_text or not help_text.startswith("{"):
+        return None
+    try:
+        help_json = json.loads(help_text)
+        return help_json.get("controlID")
+    except Exception:
+        return None
+
+
+def _get_descendant_index(win, force_refresh=False):
+    cache_key = _cache_key(win)
+    now = monotonic()
+    cached = _descendants_cache.get(cache_key)
+    if (
+        not force_refresh
+        and cached
+        and now - cached["timestamp"] < DESCENDANT_CACHE_TTL_SECONDS
+    ):
+        return cached["value"]
+
+    descendants = []
+    by_control_id = {}
+    by_exact_text = {}
+    for d in win.descendants():
+        try:
+            text = d.window_text()
+        except Exception:
+            text = ""
+
+        control_id = None
+        try:
+            control_id = _extract_control_id_from_help(
+                d.legacy_properties().get("Help", "")
+            )
+        except Exception:
+            pass
+
+        descendants.append(d)
+        if control_id and control_id not in by_control_id:
+            by_control_id[control_id] = d
+        if text and text not in by_exact_text:
+            by_exact_text[text] = d
+
+    value = {
+        "descendants": descendants,
+        "by_control_id": by_control_id,
+        "by_exact_text": by_exact_text,
+    }
+    _descendants_cache[cache_key] = {"timestamp": now, "value": value}
+    return value
+
+
 def _find_element_by_handle(target_handle):
     try:
         return Desktop(backend="uia").window(handle=int(target_handle))
@@ -45,13 +118,19 @@ def _find_element_by_handle(target_handle):
 
 
 def _find_element_by_control_id(win, control_id):
-    for d in win.descendants():
-        if get_element_data(d).get("control_id") == control_id:
-            return d
-    return None
+    if not control_id:
+        return None
+    index = _get_descendant_index(win)
+    if control_id in index["by_control_id"]:
+        return index["by_control_id"][control_id]
+
+    index = _get_descendant_index(win, force_refresh=True)
+    return index["by_control_id"].get(control_id)
 
 
 def _find_element_by_text(win, button_text):
+    if not button_text:
+        return None
     try:
         btn = win.child_window(title_re=f".*{button_text}.*", control_type="Button")
         if btn.exists():
@@ -59,7 +138,11 @@ def _find_element_by_text(win, button_text):
     except Exception:
         pass
 
-    for d in win.descendants():
+    index = _get_descendant_index(win)
+    if button_text in index["by_exact_text"]:
+        return index["by_exact_text"][button_text]
+
+    for d in index["descendants"]:
         if d.window_text() == button_text:
             return d
     return None
@@ -92,26 +175,29 @@ def list_windows():
             if class_name_filter:
                 is_match = class_name == class_name_filter
             else:
-                is_match = class_name in [
-                    "ConfMultiTabContentWndClass",  # Zoom windows (can be several)
-                    "WCN_ModelessWnd",  # Menu window
-                    "zChangeNameWndClass",  # Mute all participants dialog window
-                    "ZGridMultiLevelPopupWndClass",  # More panel popup
-                    "zJoinAudioWndClass",  # Join audio dialog window
-                    "ZPFloatToolbarClass",  # Floating share toolbar
-                    "ZPShareEntranceClass",  # Share screen window
-                    "ZPMeetingWndClass",
-                ]
+                is_match = class_name in ZOOM_WINDOW_CLASS_NAMES
             if is_match:
                 is_main = False
                 if class_name == "ConfMultiTabContentWndClass":
                     try:
-                        # Create a WindowSpecification from the handle to use child_window
-                        # Main Zoom window has a descendant with class ZPControlPanelClass (can be several levels deep)
-                        win_spec = Desktop(backend="uia").window(handle=w.handle)
-                        is_main = win_spec.child_window(
-                            class_name="ZPControlPanelClass"
-                        ).exists()
+                        cache_key = _cache_key(w)
+                        now = monotonic()
+                        cached = _main_window_cache.get(cache_key)
+                        if (
+                            cached
+                            and now - cached["timestamp"] < MAIN_WINDOW_CACHE_TTL_SECONDS
+                        ):
+                            is_main = cached["value"]
+                        else:
+                            # Main Zoom window has descendant with class ZPControlPanelClass
+                            win_spec = Desktop(backend="uia").window(handle=w.handle)
+                            is_main = win_spec.child_window(
+                                class_name="ZPControlPanelClass"
+                            ).exists()
+                            _main_window_cache[cache_key] = {
+                                "timestamp": now,
+                                "value": is_main,
+                            }
                     except Exception:
                         pass
                 res.append(
@@ -165,20 +251,22 @@ def dialog_children():
         return jsonify({"success": False, "error": "class_name is required"}), 400
 
     try:
-        search_criteria = {
-            "class_name": class_name,
-            "backend": "uia",
-            "top_level_only": False,
-        }
         if parent_handle:
             parent_win = Desktop(backend="uia").window(handle=int(parent_handle))
-            search_criteria["parent"] = parent_win.element_info
-
-        elements = findwindows.find_elements(**search_criteria)
-        if not elements:
-            raise LookupError(f"No elements found for class '{class_name}'")
-
-        win = Desktop(backend="uia").window(handle=elements[0].handle)
+            descendants = parent_win.descendants()
+            scoped_matches = [d for d in descendants if d.class_name() == class_name]
+            if not scoped_matches:
+                raise LookupError(f"No elements found for class '{class_name}'")
+            win = Desktop(backend="uia").window(handle=scoped_matches[0].handle)
+        else:
+            elements = findwindows.find_elements(
+                class_name=class_name,
+                backend="uia",
+                top_level_only=False,
+            )
+            if not elements:
+                raise LookupError(f"No elements found for class '{class_name}'")
+            win = Desktop(backend="uia").window(handle=elements[0].handle)
     except Exception as e:
         error_msg = f"Dialog with class {class_name} not found relative to parent {parent_handle}: {str(e)}\n{traceback.format_exc()}"
         print(f"Error in dialog_children: {error_msg}")
@@ -186,7 +274,6 @@ def dialog_children():
 
     descendants = win.descendants()
     result = [get_element_data(d) for d in descendants if d.window_text()]
-    print(f"Found {len(result)} descendants for class {class_name}")
     return jsonify({"success": True, "result": result})
 
 
@@ -208,20 +295,9 @@ def get_element_title():
             )
 
         win = Desktop(backend="uia").window(handle=window_handle)
-
-        for d in win.descendants():
-            try:
-                try:
-                    legacy_properties = d.legacy_properties()
-                    print(legacy_properties)
-                    help_text = legacy_properties.get("Help", "")
-                except Exception:
-                    help_text = ""
-
-                if help_text and f'"{control_id}"' in help_text:
-                    return jsonify({"success": True, "title": d.window_text()})
-            except Exception:
-                continue
+        target = _find_element_by_control_id(win, control_id)
+        if target:
+            return jsonify({"success": True, "title": target.window_text()})
 
         return jsonify(
             {
@@ -253,16 +329,7 @@ def get_element_state():
             )
 
         win = Desktop(backend="uia").window(handle=window_handle)
-
-        target = None
-        for d in win.descendants():
-            try:
-                help_text = d.legacy_properties().get("Help", "")
-                if help_text and f'"{control_id}"' in help_text:
-                    target = d
-                    break
-            except Exception:
-                continue
+        target = _find_element_by_control_id(win, control_id)
 
         if not target:
             return jsonify(


### PR DESCRIPTION
### Motivation
- Reduce UIA scanning overhead so Zoom interactions (window discovery, dialog reads, button clicks) are fast and targeted. 
- Make the Python helper lifecycle automatic and easier to control from the UI (restart instead of separate start/stop) and enable an option to auto-launch Zoom when needed before meetings. 
- Make helper logs less noisy in the UI while ensuring all helper output is captured for debugging.

### Description
- Optimized `uia_helper.py` with caching and indexing: added short-lived caches for main-window detection and descendant indexes keyed by `control_id` and exact title to avoid repeated full-tree traversals and to accelerate `_find_element_by_control_id` and `_find_element_by_text` lookups. 
- Scoped dialog lookup to a provided `parent_handle` when present so `dialog_children` searches only the parent descendants instead of performing broad global element searches. 
- Electron IPC & helper coordination improvements: added per-handle cooldown and class gating before forcing Alt toggles (`showControlsIfHidden`) and cached window class names from `listZoomWindows` to avoid unnecessary probing. 
- Lifecycle and UI updates: added `restartZoomHelper` in the manager, IPC, preload, and typings, switched popup button to a single `Restart` action, added a collapsible log panel in the Zoom Manager UI, and added a 5s polling/sync to refresh/select the main Zoom window while the popup is open. 
- Auto-launch feature: added a new toggle setting `zoomMeetingManagerAutoLaunchMeeting` (default false) and wired `autoLaunchZoomMeetingIfNeeded` to trigger when background music starts, which launches the configured meeting only if no main Zoom window is present and the meeting is still in the future. 
- Routing/logging: routed `[Pip]`, `[Pip Error]`, `[Zoom Helper]`, and `[Zoom Helper Error]` messages into the helper log store for the UI panel.

### Testing
- `python -m py_compile uia_helper.py` — succeeded.
- `yarn eslint -c ./eslint.config.js './src/**/*.{js,ts,cjs,mjs,mts,vue}' './src-electron/**/*.{js,ts,cjs,mjs,mts}'` — succeeded (auto-fixed/checked during commits).
- `yarn vue-tsc --noEmit -p tsconfig.json` — produced many typecheck errors unrelated to these changes due to workspace/tsconfig resolution baseline issues in this environment (not introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c43c066cbc8331b6c0621d46eb72ce)