### PR TITLE
Use dynamic port for Zoom helper and route IPC requests to advertised base URL

### DIFF
--- a/src-electron/main/ipc.ts
+++ b/src-electron/main/ipc.ts
@@ -86,6 +86,7 @@ import {
 } from 'src-electron/main/window/window-website';
 import {
   ensureRequirementsInstalled,
+  getZoomHelperBaseUrl,
   isPythonInstalled,
   restartZoomHelper,
   startZoomHelper,
@@ -386,9 +387,18 @@ handleIpcInvoke(
     unzipFile(input, output, opts),
 );
 
+function getZoomHelperUrl(pathname: string): URL {
+  const baseUrl = getZoomHelperBaseUrl();
+  if (!baseUrl) {
+    throw new Error('Zoom helper is not ready yet');
+  }
+
+  return new URL(pathname, `${baseUrl}/`);
+}
+
 const getZoomWindows = async (className?: string) => {
   try {
-    const url = new URL('http://127.0.0.1:5000/windows');
+    const url = getZoomHelperUrl('/windows');
     if (className) {
       url.searchParams.append('class_name', className);
     }
@@ -437,7 +447,7 @@ async function fetchZoomDialogChildren(
   parentHandle?: number,
 ): Promise<ZoomUIElement[]> {
   try {
-    const url = new URL('http://127.0.0.1:5000/dialog_children');
+    const url = getZoomHelperUrl('/dialog_children');
     url.searchParams.append('class_name', className);
     if (parentHandle) {
       url.searchParams.append('parent_handle', String(parentHandle));
@@ -468,7 +478,7 @@ async function fetchZoomDialogChildren(
 
 async function sendZoomWindowKeysInternal(handle: number, keys: string) {
   try {
-    const res = await fetch('http://127.0.0.1:5000/send_keys', {
+    const res = await fetch(getZoomHelperUrl('/send_keys').toString(), {
       body: JSON.stringify({ keys, window_handle: handle }),
       headers: { 'Content-Type': 'application/json' },
       method: 'POST',
@@ -552,7 +562,7 @@ handleIpcInvoke(
     try {
       await showControlsIfHidden(handle);
 
-      const res = await fetch('http://127.0.0.1:5000/click_button', {
+      const res = await fetch(getZoomHelperUrl('/click_button').toString(), {
         body: JSON.stringify({
           button: options.title,
           control_id: options.control_id,
@@ -584,7 +594,7 @@ handleIpcInvoke(
   async (_e, handle: number, controlId: string) => {
     try {
       await showControlsIfHidden(handle);
-      const url = new URL('http://127.0.0.1:5000/get_element_title');
+      const url = getZoomHelperUrl('/get_element_title');
       url.searchParams.append('window_handle', String(handle));
       url.searchParams.append('control_id', controlId);
 
@@ -611,7 +621,7 @@ handleIpcInvoke(
   async (_e, handle: number, controlId: string) => {
     try {
       await showControlsIfHidden(handle);
-      const url = new URL('http://127.0.0.1:5000/get_element_state');
+      const url = getZoomHelperUrl('/get_element_state');
       url.searchParams.append('window_handle', String(handle));
       url.searchParams.append('control_id', controlId);
 

--- a/src-electron/main/zoom-helper-manager.ts
+++ b/src-electron/main/zoom-helper-manager.ts
@@ -13,6 +13,7 @@ import upath from 'upath';
 const { join, resolve } = upath;
 
 let pythonProcess: ChildProcessWithoutNullStreams | null = null;
+let zoomHelperPort: null | number = null;
 
 export async function ensureRequirementsInstalled(): Promise<boolean> {
   const requirementsPath = getHelperPath('requirements.txt');
@@ -39,6 +40,11 @@ export async function ensureRequirementsInstalled(): Promise<boolean> {
   });
 }
 
+export function getZoomHelperBaseUrl(): null | string {
+  if (!zoomHelperPort) return null;
+  return `http://127.0.0.1:${zoomHelperPort}`;
+}
+
 export async function isPythonInstalled(): Promise<boolean> {
   return new Promise((resolve) => {
     exec(getPythonCommand() + ' --version', (error) => {
@@ -55,6 +61,8 @@ export function restartZoomHelper() {
 export function startZoomHelper() {
   if (pythonProcess || PLATFORM !== 'win32') return;
 
+  zoomHelperPort = null;
+
   const helperPath = getHelperPath('uia_helper.py');
 
   log(`Starting Zoom Helper`, 'zoom', 'info', helperPath);
@@ -63,8 +71,18 @@ export function startZoomHelper() {
   });
 
   pythonProcess.stdout.on('data', (data: Buffer) => {
-    const msg = data.toString().trim();
-    if (msg) {
+    const messages = data
+      .toString()
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    for (const msg of messages) {
+      const portMatch = msg.match(/^ZOOM_HELPER_PORT=(\d+)$/);
+      if (portMatch) {
+        zoomHelperPort = Number(portMatch[1]);
+      }
+
       logToWindow(
         mainWindowInfo.mainWindow,
         `[Zoom Helper] ${msg}`,
@@ -89,6 +107,7 @@ export function startZoomHelper() {
   pythonProcess.on('close', (code: number) => {
     log(`Zoom Helper process exited`, 'zoom', 'warn', code);
     pythonProcess = null;
+    zoomHelperPort = null;
     logToWindow(
       mainWindowInfo.mainWindow,
       `[Zoom Helper] Process exited with code ${code}`,
@@ -105,6 +124,7 @@ export function startZoomHelper() {
       'error',
     );
     pythonProcess = null;
+    zoomHelperPort = null;
   });
 }
 
@@ -114,6 +134,8 @@ export function stopZoomHelper() {
     pythonProcess.kill();
     pythonProcess = null;
   }
+
+  zoomHelperPort = null;
 }
 
 function getHelperPath(filename: string): string {

--- a/uia_helper.py
+++ b/uia_helper.py
@@ -4,7 +4,7 @@ from time import monotonic
 
 from pywinauto import Application, Desktop, findwindows
 from flask import Flask, jsonify, request
-from waitress import serve
+from waitress import create_server
 
 app = Flask(__name__)
 ZOOM_WINDOW_CLASS_NAMES = {
@@ -419,4 +419,9 @@ def send_keys():
 
 
 if __name__ == "__main__":
-    serve(app, host="127.0.0.1", port=5000)
+    # Let waitress bind with port=0 so the OS picks and reserves a free port
+    # atomically for this process. This avoids the race in "pick a port first,
+    # close socket, then serve(port=...)" patterns.
+    server = create_server(app, host="127.0.0.1", port=0)
+    print(f"ZOOM_HELPER_PORT={server.effective_port}", flush=True)
+    server.run()


### PR DESCRIPTION
### Motivation
- Avoid hardcoding the Zoom helper port to prevent port conflicts and race conditions when starting the helper process. 
- Have the helper advertise the port it bound so the Electron main process can reliably contact it. 
- Surface failure earlier if the Zoom helper is not ready, improving error reporting when IPC calls to the helper are attempted.

### Description
- Change the Python helper to let `waitress` bind to `port=0` and print the chosen port as `ZOOM_HELPER_PORT=<port>` to stdout by using `create_server(..., port=0)` and `server.effective_port`; then run the server with `server.run()`.
- Add `zoomHelperPort` state in `zoom-helper-manager.ts`, parse `ZOOM_HELPER_PORT` lines from the helper `stdout`, and expose `getZoomHelperBaseUrl()` which returns `http://127.0.0.1:<port>` or `null` if not ready.
- Update process lifecycle handling to clear `zoomHelperPort` when the helper exits or errors, and improve stdout splitting to handle line-buffered messages.
- Replace hardcoded `http://127.0.0.1:5000/...` URLs in `ipc.ts` with calls to `getZoomHelperBaseUrl()` and add a `getZoomHelperUrl()` helper that throws when the helper is not ready.

### Testing
- No automated tests were added or modified for this change, and no test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5bf40f574833183ced21fcd2816b7)