### PR TITLE
Pre-download memorial intro/talk stream media and set local file URLs

### DIFF
--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -1047,6 +1047,49 @@ const checkMemorialDate = async () => {
     { jwIconKeyword: 'memorial', label: t('memorial-talk') },
   );
 
+  const memorialMediaWithStreamSource = [
+    ...(introSection?.items || []),
+    ...(memorialSection?.items || []),
+  ].filter((item) => !!item.streamUrl);
+
+  if (memorialMediaWithStreamSource.length) {
+    const datedAdditionalMediaDir =
+      await currentState.getDatedAdditionalMediaDirectory(selectedDate.value);
+
+    for (const mediaItem of memorialMediaWithStreamSource) {
+      if (!mediaItem.streamUrl) {
+        continue;
+      }
+
+      const existingPath =
+        mediaItem.fileUrl && isFileUrl(mediaItem.fileUrl)
+          ? fileUrlToPath(mediaItem.fileUrl)
+          : '';
+      if (existingPath && (await pathExists(existingPath))) {
+        continue;
+      }
+
+      if (!datedAdditionalMediaDir) continue;
+
+      const fallbackFilename = basename(mediaItem.streamUrl);
+      const targetFilename = basename(existingPath || fallbackFilename);
+
+      await downloadFileIfNeeded({
+        dir: datedAdditionalMediaDir,
+        filename: targetFilename,
+        lowPriority: false,
+        meetingDate: selectedDate.value,
+        size: mediaItem.filesize,
+        url: mediaItem.streamUrl,
+      });
+
+      const downloadedPath = join(datedAdditionalMediaDir, targetFilename);
+      if (await pathExists(downloadedPath)) {
+        mediaItem.fileUrl = pathToFileURL(downloadedPath);
+      }
+    }
+  }
+
   // Fetch the memorial media, including the background image and Welcome Video
   createTemporaryNotification({
     group: 'memorial-fetch',


### PR DESCRIPTION
### Motivation
- Ensure memorial "welcome-video" and "memorial-talk" media with remote stream URLs are available offline for the selected date by downloading them into the dated additional media directory.

### Description
- Collects items from the `welcome-video` and `memorial-talk` sections that have a `streamUrl` and skips items already present as local files.  
- Resolves the dated media directory via `currentState.getDatedAdditionalMediaDirectory` and invokes `downloadFileIfNeeded` to fetch each missing stream into that directory.  
- Uses `fileUrlToPath`, `pathExists`, and `pathToFileURL` to determine existing files and to populate `mediaItem.fileUrl` with a local `file:` URL after successful download.  
- This logic is executed before the existing `getMemorialMedia` flow and preserves the existing notification behavior for memorial fetch operations.

### Testing
- Ran unit tests with `npm test`, and the test suite completed successfully.  
- Ran linting with `npm run lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca864218c08331a61c06e4c32d4014)