### PR TITLE
refactor: centralize renderer platform detection

### DIFF
--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -119,10 +119,11 @@ import { whenever } from '@vueuse/core';
 import { useRouteParams } from '@vueuse/router';
 import BaseInput from 'components/form-inputs/BaseInput.vue';
 import { storeToRefs } from 'pinia';
-import { Platform, type QForm, useMeta, useQuasar } from 'quasar';
+import { type QForm, useMeta, useQuasar } from 'quasar';
 import DialogCongregationLookup from 'src/components/dialog/DialogCongregationLookup.vue';
 import { settingsDefinitions, settingsGroups } from 'src/constants/settings';
 import { errorCatcher } from 'src/helpers/error-catcher';
+import { getCurrentPlatform } from 'src/utils/platform';
 import { useCurrentStateStore } from 'stores/current-state';
 import { useJwStore } from 'stores/jw';
 import {
@@ -171,9 +172,7 @@ const expansionState = ref<Partial<Record<SettingsGroupKey, boolean>>>({});
 const settingsFormDynamic = useTemplateRef<QForm>('settingsFormDynamic');
 const settingsValid = ref(true);
 
-let PLATFORM = 'darwin';
-if (Platform.is.win) PLATFORM = 'win32';
-else if (Platform.is.linux) PLATFORM = 'linux';
+const PLATFORM = getCurrentPlatform();
 
 const settingsGroupsEntries = Object.entries(settingsGroups).filter(
   ([, group]) => !group.platforms || group.platforms.includes(PLATFORM),

--- a/src/stores/current-state.ts
+++ b/src/stores/current-state.ts
@@ -11,7 +11,6 @@ import type {
 } from 'src/types';
 
 import { defineStore } from 'pinia';
-import { Platform } from 'quasar';
 import { i18n } from 'src/boot/i18n';
 import { LONG_MEDIA_DURATION } from 'src/constants/jw';
 import { settingsDefinitions } from 'src/constants/settings';
@@ -26,6 +25,7 @@ import {
   registerCachePathProvider,
 } from 'src/utils/fs';
 import { isEmpty, isUUID } from 'src/utils/general';
+import { getCurrentPlatform } from 'src/utils/platform';
 import { useCongregationSettingsStore } from 'stores/congregation-settings';
 import { useJwStore } from 'stores/jw';
 import { useObsStateStore } from 'stores/obs-state';
@@ -84,9 +84,7 @@ const settingDefinitionEntries = Object.entries(settingsDefinitions) as [
   SettingsItem,
 ][];
 
-let PLATFORM = 'darwin';
-if (Platform.is.win) PLATFORM = 'win32';
-else if (Platform.is.linux) PLATFORM = 'linux';
+const PLATFORM = getCurrentPlatform();
 
 let zoomHelperSyncInProgress = false;
 

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,7 @@
+import { Platform } from 'quasar';
+
+export const getCurrentPlatform = (): NodeJS.Platform => {
+  if (Platform.is.win) return 'win32';
+  if (Platform.is.linux) return 'linux';
+  return 'darwin';
+};


### PR DESCRIPTION
### Motivation
- Reduce duplicated renderer-side platform detection and centralize mapping from Quasar platform flags to the NodeJS platform strings used throughout the renderer.

### Description
- Add `src/utils/platform.ts` exporting `getCurrentPlatform()` which returns `'win32' | 'linux' | 'darwin'` based on `Platform.is`.
- Replace duplicated inline `Platform.is` checks in `src/stores/current-state.ts` and `src/pages/SettingsPage.vue` with `const PLATFORM = getCurrentPlatform()` and remove the now-unused `Platform` import in those files.

### Testing
- Run `yarn eslint -c ./eslint.config.js src/pages/SettingsPage.vue src/stores/current-state.ts src/utils/platform.ts` which completed successfully.
- Pre-commit hooks via `lint-staged` ran `prettier --write` and `eslint --fix` during the commit and finished without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca915a77848331a3184701e68b6882)