### PR TITLE
Normalize and validate media window bounds before calling Electron setBounds

### DIFF
--- a/src-electron/main/__tests__/window-media.test.ts
+++ b/src-electron/main/__tests__/window-media.test.ts
@@ -66,6 +66,40 @@ describe('window-media placement helpers', () => {
     ).toBe(false);
   });
 
+  it('rejects invalid bounds before passing them to Electron', async () => {
+    const { __testables } = await import('../window/window-media');
+
+    expect(
+      __testables.normalizeWindowBounds({
+        height: 0,
+        width: 1920,
+        x: 0,
+        y: 0,
+      }),
+    ).toBeNull();
+    expect(
+      __testables.normalizeWindowBounds({
+        height: 1080,
+        width: -1,
+        x: 0,
+        y: 0,
+      }),
+    ).toBeNull();
+    expect(
+      __testables.normalizeWindowBounds({
+        height: 1080.8,
+        width: 1920.2,
+        x: 10.9,
+        y: 20.4,
+      }),
+    ).toEqual({
+      height: 1080,
+      width: 1920,
+      x: 10,
+      y: 20,
+    });
+  });
+
   it('moves a windowed media window to another display when multiple screens exist', async () => {
     const { __testables } = await import('../window/window-media');
 

--- a/src-electron/main/window/window-media.ts
+++ b/src-electron/main/window/window-media.ts
@@ -261,6 +261,24 @@ function isWindowEffectivelyFullscreen(
 }
 
 /**
+ * Ensures bounds passed to Electron are safe positive integers
+ */
+function normalizeWindowBounds(
+  bounds: Partial<Electron.Rectangle>,
+): Electron.Rectangle | null {
+  const x = Math.floor(bounds.x ?? 0);
+  const y = Math.floor(bounds.y ?? 0);
+  const width = Math.floor(bounds.width ?? 0);
+  const height = Math.floor(bounds.height ?? 0);
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
+  if (width <= 0 || height <= 0) return null;
+
+  return { height, width, x, y };
+}
+
+/**
  * Determines if the window should move to fullscreen on another display
  */
 function shouldMoveWindowedToFullscreen(
@@ -354,6 +372,7 @@ export const __testables = {
   getPreferredScreenFromPrefs,
   getTargetWhenOnMainScreen,
   isWindowEffectivelyFullscreen,
+  normalizeWindowBounds,
   shouldMoveWindowedToFullscreen,
   validateAndAdjustTarget,
 };
@@ -792,13 +811,25 @@ const setWindowPosition = (displayNr?: number, fullscreen = true) => {
         currentBounds.height !== bounds.height;
 
       if (boundsChanged) {
+        const normalizedBounds = normalizeWindowBounds(bounds);
+        if (!normalizedBounds) {
+          log(
+            '❌ [setWindowBounds] Invalid bounds, skipping setBounds:',
+            'electronWindow',
+            'log',
+            bounds,
+          );
+          isMovingWindow = false;
+          return false;
+        }
+
         log(
           '🔍 [setWindowBounds] Setting bounds:',
           'electronWindow',
           'log',
-          bounds,
+          normalizedBounds,
         );
-        mediaWindowInfo.mediaWindow.setBounds(bounds);
+        mediaWindowInfo.mediaWindow.setBounds(normalizedBounds);
       }
 
       // Focus media window
@@ -853,14 +884,13 @@ const setWindowPosition = (displayNr?: number, fullscreen = true) => {
     } else {
       // Calculate windowed bounds (HD_RESOLUTION)
       const newBounds = (() => {
-        const maxWidth = Math.min(
-          targetScreenBounds.width - 100,
-          HD_RESOLUTION[0],
-        );
-        const maxHeight = Math.min(
+        const safeAvailableWidth = Math.max(1, targetScreenBounds.width - 100);
+        const safeAvailableHeight = Math.max(
+          1,
           targetScreenBounds.height - 100,
-          HD_RESOLUTION[1],
         );
+        const maxWidth = Math.min(safeAvailableWidth, HD_RESOLUTION[0]);
+        const maxHeight = Math.min(safeAvailableHeight, HD_RESOLUTION[1]);
 
         // If the full size doesn't fit, scale down proportionally
         const scaleX = maxWidth / HD_RESOLUTION[0];


### PR DESCRIPTION
### Motivation

- Prevent invalid, fractional, or non-positive window bounds from being passed to Electron which can cause errors or undefined behavior.
- Avoid negative available sizes when calculating windowed (non-fullscreen) bounds on very small displays.

### Description

- Add `normalizeWindowBounds` to coerce `bounds` fields to integers and return `null` for invalid or non-positive dimensions. 
- Validate bounds before calling `mediaWindow.setBounds(...)`, skip setting and log if normalization fails. 
- Tighten windowed bounds calculation by clamping available width/height with `Math.max(1, ...)` and then computing `maxWidth`/`maxHeight` against `HD_RESOLUTION`. 
- Export `normalizeWindowBounds` via `__testables` and add a unit test in `src-electron/main/__tests__/window-media.test.ts` to assert invalid and fractional bounds behavior.

### Testing

- Ran unit tests with `vitest`; the updated `window-media.test.ts` (including `rejects invalid bounds before passing them to Electron`) passed. 
- Existing related window-media tests were executed and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe95bb5108331946a5d7af9701c66)