### PR TITLE
Honor memorialDate for memorial media caching and download priority; watch memorialDate in calendar

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -47,6 +47,7 @@ import { fetchMediaItems, fetchPubMediaLinks, fetchRaw } from 'src/utils/api';
 import { convertImageIfNeeded } from 'src/utils/converters';
 import {
   dateFromString,
+  datesAreSame,
   formatDate,
   getDateDiff,
   getSpecificWeekday,
@@ -107,15 +108,28 @@ const { basename, changeExt, dirname, extname, join } = path;
 const isUsablePathCache = new Map<string, boolean>();
 const inFlight = new Map<string, Promise<boolean>>();
 
+const getMemorialMediaCacheKey = (
+  langwritten: JwLangCode,
+  memorialDate?: null | string,
+) => `${langwritten}:${memorialDate || 'none'}`;
+
 const memorialMediaCache = new Map<
-  JwLangCode,
+  string,
   { bg: string; introVideos: MultimediaItem[] }
 >();
 
 const memorialMediaInFlight = new Map<
-  JwLangCode,
+  string,
   Promise<undefined | { bg: string; introVideos: MultimediaItem[] }>
 >();
+
+const isMemorialMeetingDate = (
+  meetingDate?: string,
+  memorialDate?: null | string,
+) => {
+  if (!meetingDate || !memorialDate) return false;
+  return datesAreSame(meetingDate, memorialDate);
+};
 
 const isUsablePath = async (path: string) => {
   if (isUsablePathCache.has(path)) {
@@ -1349,6 +1363,7 @@ export const getMemorialMedia = async (
 ): Promise<undefined | { bg: string; introVideos: MultimediaItem[] }> => {
   try {
     const currentStateStore = useCurrentStateStore();
+    const memorialDate = currentStateStore.currentSettings?.memorialDate;
     const year = new Date().getFullYear().toString().substring(2);
     const languages = [
       ...new Set([
@@ -1358,17 +1373,19 @@ export const getMemorialMedia = async (
     ].filter((l): l is JwLangCode => !!l);
 
     for (const langwritten of languages) {
+      const cacheKey = getMemorialMediaCacheKey(langwritten, memorialDate);
+
       if (forceRefetch) {
-        memorialMediaCache.delete(langwritten);
-        memorialMediaInFlight.delete(langwritten);
+        memorialMediaCache.delete(cacheKey);
+        memorialMediaInFlight.delete(cacheKey);
       }
 
-      if (memorialMediaCache.has(langwritten)) {
-        return memorialMediaCache.get(langwritten);
+      if (memorialMediaCache.has(cacheKey)) {
+        return memorialMediaCache.get(cacheKey);
       }
 
-      if (memorialMediaInFlight.has(langwritten)) {
-        return memorialMediaInFlight.get(langwritten);
+      if (memorialMediaInFlight.has(cacheKey)) {
+        return memorialMediaInFlight.get(cacheKey);
       }
 
       const fetchPromise = (async () => {
@@ -1427,20 +1444,20 @@ export const getMemorialMedia = async (
             await processMissingMediaInfo({
               allMedia: results.introVideos,
               isDynamicMedia: true,
-              meetingDate: currentStateStore.currentSettings?.memorialDate,
+              meetingDate: memorialDate,
             });
           }
 
           if (results.bg || results.introVideos.length) {
-            memorialMediaCache.set(langwritten, results);
+            memorialMediaCache.set(cacheKey, results);
           }
           return results;
         } finally {
-          memorialMediaInFlight.delete(langwritten);
+          memorialMediaInFlight.delete(cacheKey);
         }
       })();
 
-      memorialMediaInFlight.set(langwritten, fetchPromise);
+      memorialMediaInFlight.set(cacheKey, fetchPromise);
       const result = await fetchPromise;
       if (result) return result;
     }
@@ -2758,10 +2775,17 @@ const downloadMissingMedia = async (
   isDynamicMedia = false,
 ) => {
   try {
+    const currentStateStore = useCurrentStateStore();
+    const isMemorialMeeting =
+      !!meetingDate &&
+      isMemorialMeetingDate(
+        meetingDate,
+        currentStateStore.currentSettings?.memorialDate,
+      );
     const pubDir = await getPublicationDirectory(publication);
     await updateLastUsedDate(
       pubDir,
-      meetingDate || useCurrentStateStore().selectedDate,
+      meetingDate || currentStateStore.selectedDate,
     );
     const responseObject = await getPubMediaLinks(publication, meetingDate);
     if (!responseObject?.files) {
@@ -2836,12 +2860,11 @@ const downloadMissingMedia = async (
 
     const downloadedFile = await downloadFileIfNeeded({
       dir: pubDir,
-      lowPriority: true,
+      lowPriority: !isMemorialMeeting,
       meetingDate,
       size: bestItem.filesize,
       url: bestItem.file.url,
     });
-    const currentStateStore = useCurrentStateStore();
     for (const itemUrl of [
       currentStateStore.currentSettings?.enableSubtitles
         ? jwMediaInfo.subtitles
@@ -2859,11 +2882,11 @@ const downloadMissingMedia = async (
         await downloadFileIfNeeded({
           dir: pubDir,
           filename: itemFilename,
-          // High Priority (false) if meeting is Today or Tomorrow (diff <= 1)
-          // Low Priority (true) if meeting is in the future (diff > 1)
-          lowPriority: meetingDate
-            ? getDateDiff(meetingDate, new Date(), 'days') > 1
-            : false,
+          lowPriority: isMemorialMeeting
+            ? false
+            : meetingDate
+              ? getDateDiff(meetingDate, new Date(), 'days') > 1
+              : false,
           meetingDate,
           url: itemUrl,
         });
@@ -3161,6 +3184,12 @@ const downloadJwpub = async (
 ): Promise<DownloadedFile> => {
   try {
     const currentStateStore = useCurrentStateStore();
+    const isMemorialMeeting =
+      !!meetingDate &&
+      isMemorialMeetingDate(
+        meetingDate,
+        currentStateStore.currentSettings?.memorialDate,
+      );
     publication.fileformat = 'JWPUB';
     const handleDownloadError = () => {
       const downloadId = getPubId(publication, true);
@@ -3198,11 +3227,11 @@ const downloadJwpub = async (
 
     return await downloadFileIfNeeded({
       dir,
-      // High Priority (false) if meeting is Today or Tomorrow (diff <= 1)
-      // Low Priority (true) if meeting is in the future (diff > 1)
-      lowPriority: meetingDate
-        ? getDateDiff(meetingDate, new Date(), 'days') > 1
-        : false,
+      lowPriority: isMemorialMeeting
+        ? false
+        : meetingDate
+          ? getDateDiff(meetingDate, new Date(), 'days') > 1
+          : false,
       meetingDate,
       size: mediaLinks[0]?.filesize,
       url: mediaLinks[0]?.file.url ?? '',

--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -1491,7 +1491,6 @@ watchImmediate(
     lastExtendDirection.value = null;
 
     if (!newVal || !selectedDateObject.value?.mediaSections) return;
-    checkMemorialDate();
 
     if (isWeMeetingDay(selectedDateObject.value.date)) {
       getOrCreateMediaSection(selectedDateObject.value.mediaSections, 'pt', {
@@ -1499,6 +1498,27 @@ watchImmediate(
         jwIconKeyword: 'pt',
         label: t('pt'),
       });
+    }
+  },
+);
+
+watch(
+  () => [
+    currentCongregation.value,
+    selectedDate.value,
+    currentSettings.value?.memorialDate,
+  ],
+  (
+    [newCongregation, newSelectedDate, newMemorialDate],
+    [oldCongregation, oldSelectedDate, oldMemorialDate],
+  ) => {
+    if (!newCongregation || !newSelectedDate) return;
+    if (
+      newCongregation !== oldCongregation ||
+      newSelectedDate !== oldSelectedDate ||
+      newMemorialDate !== oldMemorialDate
+    ) {
+      checkMemorialDate();
     }
   },
 );


### PR DESCRIPTION
### Motivation

- Ensure memorial-specific media is cached and fetched per `memorialDate` to avoid serving the wrong background/videos when the memorial date changes. 
- Prioritize downloads for memorial meetings so required assets are pulled immediately for memorials. 
- Make the Media Calendar UI react when the memorial date or related settings change so `checkMemorialDate` runs as needed.

### Description

- Added `datesAreSame` import and a new helper `isMemorialMeetingDate` to detect when a meeting is the configured memorial date. 
- Switched memorial media caches/in-flight maps to use a cache key that includes `memorialDate` via `getMemorialMediaCacheKey`, and updated `getMemorialMedia` to use that key. 
- Compute `isMemorialMeeting` from `memorialDate` and use it to adjust download priority in `downloadMissingMedia` and `downloadJwpub`, and consolidated `useCurrentStateStore()` calls into a local `currentStateStore` variable where appropriate. 
- In `MediaCalendarPage.vue` added a `watch` that triggers `checkMemorialDate()` when `currentCongregation`, `selectedDate`, or `currentSettings.memorialDate` changes so the calendar updates when memorial settings change.

### Testing

- Ran TypeScript type-check and project build (`tsc` / app build) and the compile succeeded. 
- Ran the unit test suite and existing tests related to media/cache/download logic; all tests passed. 
- Ran linters and basic linting checks; no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf29a10d0833182f1684836352652)