### PR TITLE
Guard window-state update against destroyed BrowserWindow

### DIFF
--- a/src-electron/main/window/window-state.ts
+++ b/src-electron/main/window/window-state.ts
@@ -41,7 +41,6 @@ export class StatefulBrowserWindow {
   public win: BrowserWindow;
 
   private readonly fullStoreFileName: string;
-
   private readonly saveState = () => {
     try {
       ensureDirSync(dirname(this.fullStoreFileName));
@@ -55,7 +54,13 @@ export class StatefulBrowserWindow {
 
   private readonly updateState = () => {
     try {
-      const winBounds = this.win.getBounds();
+      const winBounds = this.win?.isDestroyed?.()
+        ? undefined
+        : this.win?.getBounds?.();
+
+      if (!winBounds) {
+        return;
+      }
 
       // Save the window bounds if the window is not minimized
       if (!this.win.isMinimized()) {


### PR DESCRIPTION
### Motivation
- Prevent exceptions when `updateState` runs while the `BrowserWindow` has been destroyed or is unavailable, avoiding errors during window state save.

### Description
- Compute `winBounds` using `this.win?.isDestroyed?.()` and `this.win?.getBounds?.()` and return early if no bounds are available, which prevents calling `isMinimized`, `isMaximized`, and `isFullScreen` on a destroyed window while preserving existing error capture logic.

### Testing
- Built the TypeScript project with `yarn build` and ran the test suite with `yarn test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9b0e236883318cb5aa4b4d14dca6)