### PR TITLE
Handle memorial-replaced weeks in media fetchers

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -28,7 +28,12 @@ import {
   MAX_SONGS,
 } from 'src/constants/jw';
 import mepslangs from 'src/constants/mepslangs';
-import { isCoWeek, isMwMeetingDay, isWeMeetingDay } from 'src/helpers/date';
+import {
+  isCoWeek,
+  isMwMeetingDay,
+  isReplacedByMemorial,
+  isWeMeetingDay,
+} from 'src/helpers/date';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { exportAllDays } from 'src/helpers/export-media';
 import {
@@ -2013,6 +2018,16 @@ export const getWeMedia = async (lookupDate: Date) => {
   try {
     const currentStateStore = useCurrentStateStore();
     lookupDate = dateFromString(lookupDate);
+
+    // The weekend meeting is replaced by the Memorial when the Memorial falls
+    // on a weekend day in the same week as this lookup date.
+    if (isReplacedByMemorial(lookupDate)) {
+      return {
+        error: false,
+        media: {} as Record<string, MediaItem[]>,
+      };
+    }
+
     const monday = getSpecificWeekday(lookupDate, 0);
 
     const getIssueWithFallback = async (
@@ -2417,6 +2432,16 @@ export const getMwMedia = async (lookupDate: Date) => {
   try {
     const currentStateStore = useCurrentStateStore();
     lookupDate = dateFromString(lookupDate);
+
+    // The midweek meeting is replaced by the Memorial when the Memorial falls
+    // on a weekday in the same week as this lookup date.
+    if (isReplacedByMemorial(lookupDate)) {
+      return {
+        error: false,
+        media: {} as Record<string, MediaItem[]>,
+      };
+    }
+
     // if not monday, get the previous monday
     const monday = getSpecificWeekday(lookupDate, 0);
     const issue = subtractFromDate(monday, {


### PR DESCRIPTION
### Motivation
- Fetching media for a midweek or weekend meeting could fail when the Memorial falls in the same week (weekday vs weekend), producing errors like `No document id found for ... mwb_*.db` because the regular meeting is replaced by the Memorial.
- Short-circuiting the media fetchers for weeks that are replaced by the Memorial avoids unnecessary DB lookups and false error states.

### Description
- Added `isReplacedByMemorial` import to `src/helpers/jw-media.ts` to detect weeks replaced by the Memorial.
- Added an early return in `getWeMedia` that checks `isReplacedByMemorial(lookupDate)` and returns `{ error: false, media: {} }` when the weekend meeting is replaced by the Memorial.
- Added an early return in `getMwMedia` that checks `isReplacedByMemorial(lookupDate)` and returns `{ error: false, media: {} }` when the midweek meeting is replaced by the Memorial.

### Testing
- Ran `yarn eslint -c ./eslint.config.js src/helpers/jw-media.ts`, which completed successfully.
- Pre-commit hooks ran `prettier --write --ignore-unknown` and `eslint --fix` on staged files, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27281eabc83319d106ddd1cff3204)