### PR TITLE
Make memorial media resilient to connection blips and add backup background media item

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -3226,16 +3226,58 @@ const downloadJwpub = async (
         currentStateStore.currentSettings?.memorialDate,
       );
     publication.fileformat = 'JWPUB';
-    const handleDownloadError = () => {
+    const isValidJwpubArchive = async (jwpubPath?: string) => {
+      if (!jwpubPath) return false;
+      try {
+        const entries = await getZipEntries(jwpubPath);
+        return !!entries['contents'];
+      } catch (error) {
+        log(
+          `[downloadJwpub] Corrupt JWPUB detected at ${jwpubPath}.`,
+          'mediaFetching',
+          'warn',
+          error,
+        );
+        return false;
+      }
+    };
+
+    const getExistingJwpub = async (dir: string): Promise<DownloadedFile> => {
+      try {
+        if (!(await pathExists(dir))) {
+          return { new: false, path: '' };
+        }
+
+        const files = await readdir(dir);
+        for (const file of files) {
+          const filename = file?.name || '';
+          if (!filename.toLowerCase().endsWith('.jwpub')) continue;
+
+          const jwpubPath = join(dir, filename);
+          if (await isValidJwpubArchive(jwpubPath)) {
+            return {
+              new: false,
+              path: jwpubPath,
+            };
+          }
+        }
+      } catch (error) {
+        errorCatcher(error);
+      }
+      return { new: false, path: '' };
+    };
+
+    const publicationDir = await getPublicationDirectory(publication);
+
+    const handleDownloadError = async () => {
       const downloadId = getPubId(publication, true);
       currentStateStore.downloadProgress[downloadId] = {
         error: true,
         filename: downloadId,
       };
-      return {
-        new: false,
-        path: '',
-      };
+      const cachedJwpub = await getExistingJwpub(publicationDir);
+      if (cachedJwpub.path) return cachedJwpub;
+      return { new: false, path: '' };
     };
     const publicationInfo = await getPubMediaLinks(publication, meetingDate);
     if (!publicationInfo?.files) {
@@ -3257,8 +3299,7 @@ const downloadJwpub = async (
       return handleDownloadError();
     }
 
-    const dir = await getPublicationDirectory(publication);
-    await updateLastUsedDate(dir, meetingDate || new Date());
+    await updateLastUsedDate(publicationDir, meetingDate || new Date());
 
     let lowPriority = false;
 
@@ -3267,27 +3308,11 @@ const downloadJwpub = async (
     }
 
     const downloadOptions = {
-      dir,
+      dir: publicationDir,
       lowPriority,
       meetingDate,
       size: mediaLinks[0]?.filesize,
       url: mediaLinks[0]?.file.url ?? '',
-    };
-
-    const isValidJwpubArchive = async (jwpubPath?: string) => {
-      if (!jwpubPath) return false;
-      try {
-        const entries = await getZipEntries(jwpubPath);
-        return !!entries['contents'];
-      } catch (error) {
-        log(
-          `[downloadJwpub] Corrupt JWPUB detected at ${jwpubPath}.`,
-          'mediaFetching',
-          'warn',
-          error,
-        );
-        return false;
-      }
     };
 
     const firstAttempt = await downloadFileIfNeeded(downloadOptions);

--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -1009,6 +1009,33 @@ const checkMemorialDate = async () => {
           type: 'positive',
         });
       }
+
+      // Add Memorial background image as backup media item after welcome video(s)
+      if (introSection && memorialMedia.bg) {
+        introSection.items ??= [];
+
+        const memorialBgFileUrl = isFileUrl(memorialMedia.bg)
+          ? memorialMedia.bg
+          : pathToFileURL(memorialMedia.bg);
+
+        const hasMemorialBgInWelcomeSection = introSection.items.some(
+          (item) =>
+            item.source === 'dynamic' &&
+            item.isImage &&
+            item.fileUrl === memorialBgFileUrl,
+        );
+
+        if (!hasMemorialBgInWelcomeSection) {
+          introSection.items.push({
+            fileUrl: memorialBgFileUrl,
+            isImage: true,
+            source: 'dynamic',
+            title: 'Memorial Background',
+            type: 'media',
+            uniqueId: uuid(),
+          });
+        }
+      }
     } else {
       createTemporaryNotification({
         group: 'memorial-fetch',

--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -852,12 +852,20 @@ const checkMemorialDate = async () => {
   if (checkMemorialDateRunning) return;
   checkMemorialDateRunning = true;
   try {
-    if (
-      !selectedDate.value ||
-      selectedDate.value !== currentSettings.value?.memorialDate ||
-      !selectedDateObject.value?.mediaSections
-    ) {
+    const isMemorialDateSelected =
+      !!selectedDate.value &&
+      selectedDate.value === currentSettings.value?.memorialDate;
+
+    if (!selectedDate.value || !isMemorialDateSelected) {
       postCustomBackground(mediaWindowCustomBackground.value ?? '');
+      return;
+    }
+
+    // Keep existing Memorial background during transient calendar refreshes.
+    // selectedDateObject can briefly lose mediaSections while lookup data updates
+    // (e.g. connection blips/reconnects), and posting '' here would revert display
+    // back to yeartext even though Memorial mode is still active.
+    if (!selectedDateObject.value?.mediaSections) {
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent the Memorial background from disappearing when a temporary network blip prevents fetching the remote JWPUB and provide a local backup media item in the Welcome Video section. 

### Description
- In `src/helpers/jw-media.ts` added `isValidJwpubArchive` and `getExistingJwpub` and changed `downloadJwpub` to prefer a previously cached, validated `.jwpub` in the publication directory when online lookups/downloads fail by returning that cached file from error paths. 
- Updated `downloadJwpub` to use the resolved `publicationDir` for `updateLastUsedDate` and the download target via `downloadOptions.dir`. 
- In `src/pages/MediaCalendarPage.vue` appended the Memorial background image as a `dynamic` image `MediaItem` into the `welcome-video` section (using `pathToFileURL` / `isFileUrl`) so operators have an explicit image media backup after any welcome videos. 
- Added duplicate protection so the same Memorial background image is not inserted multiple times, and used `uuid()` for generated `uniqueId` values. 

### Testing
- Ran `pnpm exec eslint src/helpers/jw-media.ts src/pages/MediaCalendarPage.vue` on the modified files and it passed. 
- Pre-commit formatting and lint hooks (Prettier + ESLint) were executed for the changed files and passed. 
- Ran `pnpm exec vue-tsc --noEmit -p tsconfig.json` which failed due to repository/environment-wide TypeScript and module-resolution issues unrelated to these changes (missing `.quasar/tsconfig.json` and many pre-existing type resolution errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2739b07bc8331863cf254603ba114)