### PR TITLE
Fix empty-state "next day with media" skipping today

### DIFF
--- a/src/components/media/MediaEmptyState.vue
+++ b/src/components/media/MediaEmptyState.vue
@@ -97,7 +97,7 @@
             "
             class="row items-center justify-center q-mt-lg q-gutter-md"
           >
-            <q-btn color="primary" outline @click="goToNextDayWithMedia(true)">
+            <q-btn color="primary" outline @click="goToNextDayWithMedia()">
               <q-icon class="q-mr-sm" name="mmm-go-to-date" size="xs" />
               {{ t('next-day-with-media') }}
             </q-btn>


### PR DESCRIPTION
### Motivation
- The empty-state button called `goToNextDayWithMedia(true)`, which made the selection logic treat today as past and skip it, causing the app to jump to a later meeting instead of today's meeting.

### Description
- Change the empty-state action in `src/components/media/MediaEmptyState.vue` to call `goToNextDayWithMedia()` (no `true` argument) so today remains eligible when finding the next date with media.

### Testing
- Confirmed the template now invokes `goToNextDayWithMedia()` and attempted to run `eslint` (`yarn run -T eslint -c ./eslint.config.js src/components/media/MediaEmptyState.vue`), but the lint run failed because local dependencies (`node_modules`) are not installed in this environment, so no further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2769da99c83319dd649de59c2e1a2)