### PR TITLE
Silence meeting media fetch errors for past dates

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -56,6 +56,7 @@ import {
   formatDate,
   getDateDiff,
   getSpecificWeekday,
+  isInPast,
   subtractFromDate,
 } from 'src/utils/date';
 import {
@@ -766,15 +767,24 @@ export const fetchMedia = async () => {
               if (!day.mediaSections) day.mediaSections = [];
               createMeetingSections(day);
               replaceMissingMediaByPubMediaId(day, fetchResult.media);
-              day.status = fetchResult.error ? 'error' : 'complete';
+              if (fetchResult.error && isInPast(dayDate)) {
+                log(
+                  `⚠️ Silencing meeting media fetch error for past date ${formatDate(dayDate, 'YYYY/MM/DD')}`,
+                  'mediaFetching',
+                  'warn',
+                );
+                day.status = 'complete';
+              } else {
+                day.status = fetchResult.error ? 'error' : 'complete';
+              }
             } else {
               log('❌ Failed to fetch media', 'mediaFetching', 'error');
-              day.status = 'error';
+              day.status = isInPast(dayDate) ? 'complete' : 'error';
             }
           })
           .catch((error) => {
             log('❌ Error during media processing:', 'mediaFetching', 'error');
-            day.status = 'error';
+            day.status = isInPast(day.date) ? 'complete' : 'error';
             throw error;
           });
       } catch (error) {


### PR DESCRIPTION
### Motivation
- Prevent noisy/incorrect error states when the app attempts to refresh meeting media for historical dates (e.g., when a memorial date has been removed because it is in the past). 

### Description
- Adjusted the meeting fetch pipeline in `src/helpers/jw-media.ts` to treat fetch failures for past lookup dates as non-fatal by marking those days `complete` instead of `error`.
- Added a warning log (`Silencing meeting media fetch error for past date ...`) so the event is visible in logs without surfacing a user-facing error state.
- Applied the same past-date tolerance for both error responses and thrown errors inside the queue processing logic using the `isInPast` helper.
- Imported `isInPast` from `src/utils/date` and updated status-handling branches accordingly.

### Testing
- Ran the linter on the modified file with `yarn run eslint -c ./eslint.config.js './src/helpers/jw-media.ts'` which completed successfully.
- Attempted to run `yarn run vitest --project quasar src/utils/__tests__/date.test.ts`, but the test run failed in this environment due to a missing Quasar-generated `tsconfig.json` and an environment Node/Quasar preparation mismatch, so full unit test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d28332ddb08331b1f73d3bc3146c02)