### PR TITLE
Fix memorial replacement checks and one-month retention for fetched memorials

### DIFF
--- a/src/helpers/date.ts
+++ b/src/helpers/date.ts
@@ -99,27 +99,30 @@ const shouldUseChangedMeetingSchedule = (lookupDate?: Date | string) => {
 export const isReplacedByMemorial = (lookupDate?: Date) => {
   try {
     const currentState = useCurrentStateStore();
-    if (
-      !lookupDate ||
-      currentState.currentSettings?.disableMediaFetching ||
-      !currentState.currentSettings?.memorialDate
-    ) {
+    const jwStore = useJwStore();
+    if (!lookupDate || currentState.currentSettings?.disableMediaFetching) {
       return false;
     }
 
     lookupDate = dateFromString(lookupDate);
-    const memorialDate = dateFromString(
-      currentState.currentSettings.memorialDate,
-    );
-
-    const memorialInWeekend = [0, 6].includes(memorialDate.getDay());
     const lookupDateInWeekend = [0, 6].includes(lookupDate.getDay());
-
-    if (memorialInWeekend !== lookupDateInWeekend) return false;
-    return datesAreSame(
-      getSpecificWeekday(lookupDate, 0),
-      getSpecificWeekday(memorialDate, 0),
+    const lookupWeekMonday = getSpecificWeekday(lookupDate, 0);
+    const memorialDates = [
+      ...Object.values(jwStore.memorials ?? {}),
+      currentState.currentSettings?.memorialDate,
+    ].filter((memorialDate): memorialDate is `${number}/${number}/${number}` =>
+      Boolean(memorialDate),
     );
+
+    return memorialDates.some((memorialDate) => {
+      const parsedMemorialDate = dateFromString(memorialDate);
+      const memorialInWeekend = [0, 6].includes(parsedMemorialDate.getDay());
+      if (memorialInWeekend !== lookupDateInWeekend) return false;
+      return datesAreSame(
+        lookupWeekMonday,
+        getSpecificWeekday(memorialDate, 0),
+      );
+    });
   } catch (error) {
     errorCatcher(error);
     return false;

--- a/src/utils/__tests__/api.test.ts
+++ b/src/utils/__tests__/api.test.ts
@@ -131,10 +131,12 @@ describe('fetchMemorials', () => {
     clearFetchCache();
   });
 
-  it('filters out past, malformed, and non-numeric memorial entries', async () => {
-    vi.spyOn(dateUtils, 'isInPast').mockImplementation(
-      (value) => value === '2024/03/24',
-    );
+  it('filters out memorials that are more than one month old, malformed, and non-numeric entries', async () => {
+    vi.spyOn(dateUtils, 'isInPast').mockImplementation((value) => {
+      const dateValue = new Date(value);
+      if (Number.isNaN(dateValue.getTime())) return false;
+      return dateValue.toISOString().startsWith('2024-04-24');
+    });
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(
         JSON.stringify({

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -11,7 +11,7 @@ import type {
 
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { log } from 'src/shared/vanilla';
-import { isInPast } from 'src/utils/date';
+import { addToDate, dateFromString, isInPast } from 'src/utils/date';
 import { betaUpdatesDisabled } from 'src/utils/fs';
 
 const fetchCache = new Map<string, Response>();
@@ -236,8 +236,10 @@ export const fetchMemorials = async (): Promise<null | Record<
       try {
         if (!key || !value || /[a-zA-Z]/.test(value)) continue;
 
-        const valueIsInPast = isInPast(value);
-        if (valueIsInPast) continue;
+        const valueIsMoreThanOneMonthInPast = isInPast(
+          addToDate(dateFromString(value), { months: 1 }),
+        );
+        if (valueIsMoreThanOneMonthInPast) continue;
 
         const year = Number.parseInt(key);
         if (!year || Number.isNaN(year)) continue;


### PR DESCRIPTION
### Motivation
- Ensure memorial replacement checks consider all known memorial dates (fetched and configured) so weekend/midweek media replacement works even for memorials slightly in the past. 
- Avoid immediately dropping recently passed memorial dates from the store so media lookups in the weeks after a memorial still recognize that the week was a memorial.

### Description
- Updated `isReplacedByMemorial` to read memorial dates from `jwStore.memorials` and include the current settings `memorialDate` as a fallback, and to compare the lookup week against every memorial date instead of a single date (file: `src/helpers/date.ts`).
- Updated `fetchMemorials` to only filter out a memorial when it is more than one month in the past by checking `isInPast(addToDate(parsedDate, { months: 1 }))` (file: `src/utils/api.ts`).
- Adjusted the `fetchMemorials` unit test to reflect the new one-month retention behavior (file: `src/utils/__tests__/api.test.ts`).

### Testing
- Ran `yarn eslint -c ./eslint.config.js src/helpers/date.ts src/utils/api.ts src/utils/__tests__/api.test.ts` which completed successfully.
- Ran `yarn vitest --project quasar src/utils/__tests__/api.test.ts` but the test run failed in this environment due to a missing `.quasar/tsconfig.json` (environment configuration issue), so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d292377d44833184ea3a0c429d3733)