### PR TITLE
Add download queue pause control and detailed queue diagnostics; delay background music until meeting fetch completes

### DIFF
--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -113,6 +113,7 @@ const electronApi: ElectronApi = {
   parseMediaFile,
   path,
   pathToFileURL,
+  pauseAllDownloads: () => send('pauseAllDownloads'),
   PLATFORM,
   quitAndInstall: () => send('quitAndInstall'),
   readdir: readDirectory,

--- a/src-electron/main/downloads.ts
+++ b/src-electron/main/downloads.ts
@@ -170,6 +170,47 @@ function hasHighPriorityActive(
   return Array.from(activeDownloads.values()).some((d) => !d.lowPriority);
 }
 
+function logDownloadQueueDebugState(reason: string): void {
+  const activeDownloads = getActiveDownloads();
+  const pausedDownloads = getPausedDownloads();
+  const activeDetails = Array.from(activeDownloads.entries()).map(
+    ([key, download]) => ({
+      hasUuid: !!download.uuid,
+      key,
+      lowPriority: download.lowPriority,
+      pauseRequested: !!download.pauseRequested,
+      state: download.state,
+      url: download.item.url,
+    }),
+  );
+  const pausedDetails = Array.from(pausedDownloads.entries()).map(
+    ([key, download]) => ({
+      hasUuid: !!download.uuid,
+      key,
+      lowPriority: download.lowPriority,
+      pauseRequested: !!download.pauseRequested,
+      state: download.state,
+      url: download.item.url,
+    }),
+  );
+
+  log(
+    `Download queue debug snapshot (${reason})`,
+    'electronDownloads',
+    'warn',
+    {
+      activeCount: activeDownloads.size,
+      activeDownloads: activeDetails,
+      lowPriorityQueueLength: lowPriorityQueue.length,
+      lowPriorityQueueTop: lowPriorityQueue[0]?.url,
+      normalQueueLength: downloadQueue.length,
+      normalQueueTop: downloadQueue[0]?.url,
+      pausedCount: pausedDownloads.size,
+      pausedDownloads: pausedDetails,
+    },
+  );
+}
+
 function logPausedDownloadsContext(reason: string): void {
   const pausedDownloads = getPausedDownloads();
   if (pausedDownloads.size === 0) return;
@@ -493,6 +534,72 @@ export async function isDownloadComplete(downloadId: string) {
 }
 
 /**
+ * Pause all active downloads.
+ */
+export async function pauseAllDownloads(reason = 'manual') {
+  const loadedManager = await loadElectronDownloadManager();
+  if (!loadedManager) return;
+
+  const activeDownloads = getActiveDownloads();
+  if (activeDownloads.size === 0) {
+    log(
+      `pauseAllDownloads called (${reason}) but there were no active downloads`,
+      'electronDownloads',
+      'log',
+    );
+    return;
+  }
+
+  log(
+    `Pausing ${activeDownloads.size} active downloads (${reason})`,
+    'electronDownloads',
+    'warn',
+  );
+  logDownloadQueueDebugState(`before pause-all (${reason})`);
+
+  activeDownloads.forEach((download, key) => {
+    if (!download.uuid) {
+      download.pauseRequested = true;
+      download.state = DownloadState.PAUSED;
+      log(
+        `Pause requested before uuid assignment (${reason})`,
+        'electronDownloads',
+        'warn',
+        key,
+        download.item.url,
+      );
+      return;
+    }
+
+    try {
+      download.state = DownloadState.PAUSED;
+      loadedManager.pauseDownload(download.uuid);
+      log(
+        `Paused download (${reason})`,
+        'electronDownloads',
+        'warn',
+        key,
+        download.item.url,
+      );
+    } catch (error) {
+      captureElectronError(error, {
+        contexts: {
+          fn: {
+            download,
+            key,
+            name: 'downloads.ts pauseAllDownloads',
+            reason,
+          },
+        },
+      });
+    }
+  });
+
+  logDownloadQueueDebugState(`after pause-all (${reason})`);
+  addQueueBreadcrumb(`pause-all-${reason}`, { force: true });
+}
+
+/**
  * Attempts to resume every paused download and kick queue processing.
  */
 export async function resumeAllDownloads(reason = 'manual') {
@@ -594,6 +701,7 @@ function stopLowPriorityDownloads(reason = 'high-priority-enqueued') {
   });
   if (pausedAny) {
     logPausedDownloadsContext(`stopLowPriorityDownloads (${reason})`);
+    logDownloadQueueDebugState(`stopLowPriorityDownloads (${reason})`);
     addQueueBreadcrumb('low-priority-paused-for-high-priority', {
       force: true,
     });
@@ -813,6 +921,7 @@ async function processQueue() {
         'warn',
       );
       logPausedDownloadsContext('auto-resume-stalled-queue');
+      logDownloadQueueDebugState('auto-resume-stalled-queue');
       await resumeAllDownloads('auto-stalled-queue');
     }
     return;

--- a/src-electron/main/ipc.ts
+++ b/src-electron/main/ipc.ts
@@ -31,6 +31,7 @@ import {
   downloadFile,
   isDownloadComplete,
   isDownloadErrorExpected,
+  pauseAllDownloads,
   resumeAllDownloads,
 } from 'src-electron/main/downloads';
 import { createVideoFromNonVideo } from 'src-electron/main/ffmpeg';
@@ -152,6 +153,10 @@ handleIpcSend('cancelAllDownloads', () => {
 
 handleIpcSend('resumeAllDownloads', () => {
   resumeAllDownloads('renderer-manual');
+});
+
+handleIpcSend('pauseAllDownloads', () => {
+  pauseAllDownloads('renderer-manual');
 });
 
 handleIpcSend('checkForUpdates', () => triggerUpdateCheck());

--- a/src/components/dialog/DialogDownloadsPopup.vue
+++ b/src/components/dialog/DialogDownloadsPopup.vue
@@ -122,6 +122,15 @@
         <q-btn
           color="secondary"
           flat
+          icon="mmm-pause"
+          :label="t('pause')"
+          @click="onPauseAllDownloads"
+        >
+          <q-tooltip>{{ t('pause') }}</q-tooltip>
+        </q-btn>
+        <q-btn
+          color="secondary"
+          flat
           icon="mmm-play"
           :label="t('resume')"
           @click="onResumeAllDownloads"
@@ -406,5 +415,9 @@ const onRefreshMeetingMedia = () => {
 
 const onResumeAllDownloads = () => {
   globalThis.electronApi.resumeAllDownloads();
+};
+
+const onPauseAllDownloads = () => {
+  globalThis.electronApi.pauseAllDownloads();
 };
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -77,6 +77,7 @@ import { watchExternalFolder } from 'src/helpers/fs';
 import {
   downloadBackgroundMusic,
   downloadSongbookVideos,
+  fetchMedia,
   getJwMepsInfo,
   setUrlVariables,
   watchedItemMapper,
@@ -293,6 +294,7 @@ watch(currentCongregation, async (newCongregation, oldCongregation) => {
     const scheduleChanged = !!(await syncMeetingSchedule());
 
     updateLookupPeriod({ reset: scheduleChanged });
+    await fetchMedia();
     downloadBackgroundMusic();
     delayedCacheClear();
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -207,6 +207,7 @@ export interface ElectronApi {
    *   // => 'file:///home/user/document.pdf'
    */
   pathToFileURL: (path: string) => string;
+  pauseAllDownloads: () => void;
   PLATFORM: string;
   quitAndInstall: () => void;
   readdir: (
@@ -295,6 +296,7 @@ export type ElectronIpcSendKey =
   | 'navigateWebsiteWindow'
   | 'openDiscussion'
   | 'openExternal'
+  | 'pauseAllDownloads'
   | 'quitAndInstall'
   | 'resumeAllDownloads'
   | 'setElectronUrlVariables'


### PR DESCRIPTION
### Motivation
- Investigate and prevent the bug where all downloads become paused after switching or refreshing congregations by making queue state visible and adding a manual pause control. 
- Ensure background music downloads don't race ahead of meeting media fetching by only starting them once meeting media fetch is finished.

### Description
- Added a detailed download-queue snapshot logger `logDownloadQueueDebugState` and inserted calls when low-priority downloads are paused and when the queue is detected stalled to record active/paused/pending items (`src-electron/main/downloads.ts`).
- Implemented a new `pauseAllDownloads()` flow in the Electron download manager and added detailed logging around the pause operation (`src-electron/main/downloads.ts`).
- Exposed pause/resume control end-to-end: IPC handler in `src-electron/main/ipc.ts`, preload bridge in `src-electron/electron-preload.ts`, and renderer typing in `src/types/electron.d.ts`, and added a **Pause** button in the Downloads popup UI wired to `electronApi.pauseAllDownloads()` (`src/components/dialog/DialogDownloadsPopup.vue`).
- Changed congregation-switch sequence to `await fetchMedia()` before calling `downloadBackgroundMusic()` to avoid starting BG music downloads until meeting media fetching completes (`src/layouts/MainLayout.vue`).

### Testing
- Ran targeted ESLint on modified files with `yarn eslint -c ./eslint.config.js src-electron/main/downloads.ts src-electron/main/ipc.ts src-electron/electron-preload.ts src/types/electron.d.ts src/layouts/MainLayout.vue src/components/dialog/DialogDownloadsPopup.vue` which completed successfully for those files.
- Ran project-wide `yarn lint` which failed in this environment due to missing Quasar-generated TypeScript config and unrelated type-resolution errors (errors originate from broader workspace environment, not the localized changes made here).
- Confirmed files were committed (`git` commit created) and UI hook points were added; no unit test suite was executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2bae342d08331a38c59525c9eea96)