### PR TITLE
fix(timer): preserve timer windowed bounds during media playback sync

### DIFF
--- a/src-electron/main/window/window-timer.ts
+++ b/src-electron/main/window/window-timer.ts
@@ -257,6 +257,18 @@ export const moveTimerWindow = (displayNr?: number, fullscreen?: boolean) => {
       // Check if timer window is fullscreen
       const isCurrentlyFullscreen = timerWindowInfo.timerWindow.isFullScreen();
 
+      // Keep user-defined windowed size/position when no explicit move request was made.
+      // This avoids unexpected resizing when unrelated actions (e.g. media playback)
+      // trigger a generic timer-window sync.
+      if (!isCurrentlyFullscreen) {
+        log(
+          '🔍 [moveTimerWindow] Timer window is windowed and no explicit target was provided; keeping current bounds',
+          'timer',
+          'log',
+        );
+        return;
+      }
+
       log('🔍 [moveTimerWindow] Current state:', 'timer', 'log', {
         currentBounds,
         currentDisplayNr,


### PR DESCRIPTION
### Motivation
- Users reported the timer window being unexpectedly maximized when starting media playback; media playback path calls a generic timer sync which could override a user-resized windowed timer.
- The no-argument branch of `moveTimerWindow()` could still choose a fullscreen relocation, ignoring user windowed bounds and causing surprising resizing.

### Description
- Add an early return in `moveTimerWindow()` when it is invoked without explicit `displayNr`/`fullscreen` parameters and the timer window is currently windowed, preserving user-defined size/position.
- Add a log message to document the intentional preservation of windowed bounds in that implicit/no-arg sync path.
- Change is confined to `src-electron/main/window/window-timer.ts` and preserves existing fullscreen/explicit-moving behavior.

### Testing
- Ran linter: `yarn eslint -c ./eslint.config.js src-electron/main/window/window-timer.ts` which completed successfully.
- Attempted unit run: `yarn vitest --project electron src-electron/main/__tests__/screen.test.ts` but the test run could not complete in this environment due to a missing build artifact (`.quasar/tsconfig.json`), so unit tests were not executed here (environment failure).
- No other automated tests were impacted by this change in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76bf0a70c8331a9284d9605ee76c4)