### PR TITLE
Treat adaptive default end times as non-custom and fix WT adaptive end-time for CO weeks

### DIFF
--- a/src/composables/useTimer.ts
+++ b/src/composables/useTimer.ts
@@ -443,7 +443,10 @@ const useTimer = () => {
           (isCo
             ? partDurations.value['abbreviated-wt']
             : partDurations.value.wt) * 60;
-        if (wtCustomEndTime.value) {
+        if (
+          wtCustomEndTime.value &&
+          wtCustomEndTime.value !== wtAdaptiveDefaultEndTime.value
+        ) {
           // Custom end time
           const configuredMeetingStartTime = currentSettings.value?.weStartTime;
           if (!configuredMeetingStartTime) return 0;
@@ -492,7 +495,10 @@ const useTimer = () => {
         return partDurations.value['co-service-talk'] * 60;
       } else if (currentPart.value === 'cbs') {
         const cbsMaxDuration = partDurations.value.cbs * 60;
-        if (cbsCustomEndTime.value) {
+        if (
+          cbsCustomEndTime.value &&
+          cbsCustomEndTime.value !== cbsAdaptiveDefaultEndTime.value
+        ) {
           // Custom end time
           const configuredMeetingStartTime = currentSettings.value?.mwStartTime;
           if (!configuredMeetingStartTime) return 0;
@@ -876,11 +882,12 @@ const useTimer = () => {
   });
 
   const wtAdaptiveDefaultEndTime = computed(() => {
-    const startTime = getPlannedStartTime('wt');
-    if (!startTime) return '';
     const date = selectedDateObject.value?.date;
     const isCo = date ? isCoWeek(date) : false;
-    const durationKey = isCo ? 'abbreviated-wt' : 'wt';
+    const wtPart = isCo ? 'abbreviated-wt' : 'wt';
+    const startTime = getPlannedStartTime(wtPart);
+    if (!startTime) return '';
+    const durationKey = wtPart;
     const duration = partDurations.value[durationKey] * 60 * 1000;
     const endTime = new Date(startTime + duration);
     return endTime.toTimeString().slice(0, 5); // hh:mm


### PR DESCRIPTION
### Motivation
- Prevent treating an adaptive default end-time string as a user-provided custom end time which could incorrectly apply custom end-time logic and truncate timers. 
- Ensure the WT adaptive default end-time is computed using the correct planned start time for CO weeks so the displayed default end time matches the intended variant.

### Description
- Update custom-end-time checks to ignore values that are equal to the adaptive default by requiring `...CustomEndTime.value && ...CustomEndTime.value !== ...AdaptiveDefaultEndTime.value` for both WT and CBS. 
- Adjust the `wtAdaptiveDefaultEndTime` computed to select the correct WT part key (`'abbreviated-wt'` for CO weeks or `'wt'` otherwise), obtain the planned start with `getPlannedStartTime(wtPart)`, and use that duration key for the end-time calculation. 
- Keep existing custom end-time handling and meeting start/time calculations otherwise unchanged.

### Testing
- Ran unit tests with `yarn test` and they passed. 
- Ran TypeScript compilation with `yarn build` and the project compiled successfully. 
- Ran linter with `yarn lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e76bda02b883318860e7d4824a8579)