### PR TITLE
Preserve windowed media bounds when no explicit target is provided

### DIFF
--- a/src-electron/main/__tests__/window-media.test.ts
+++ b/src-electron/main/__tests__/window-media.test.ts
@@ -131,6 +131,60 @@ describe('window-media placement helpers', () => {
     expect(result).toEqual({ shouldMove: true, targetDisplayNr: 1 });
   });
 
+  it('keeps windowed media bounds when no explicit display/mode target is provided', async () => {
+    const { __testables } = await import('../window/window-media');
+
+    expect(
+      __testables.shouldKeepWindowedWithoutExplicitTarget(
+        undefined,
+        undefined,
+        false,
+        true,
+        false,
+      ),
+    ).toBe(true);
+
+    expect(
+      __testables.shouldKeepWindowedWithoutExplicitTarget(
+        1,
+        false,
+        false,
+        true,
+        false,
+      ),
+    ).toBe(false);
+
+    expect(
+      __testables.shouldKeepWindowedWithoutExplicitTarget(
+        undefined,
+        undefined,
+        true,
+        true,
+        false,
+      ),
+    ).toBe(false);
+
+    expect(
+      __testables.shouldKeepWindowedWithoutExplicitTarget(
+        undefined,
+        undefined,
+        false,
+        false,
+        false,
+      ),
+    ).toBe(false);
+
+    expect(
+      __testables.shouldKeepWindowedWithoutExplicitTarget(
+        undefined,
+        undefined,
+        false,
+        true,
+        true,
+      ),
+    ).toBe(false);
+  });
+
   it('keeps single-screen setups windowed instead of forcing fullscreen', async () => {
     const { __testables } = await import('../window/window-media');
 

--- a/src-electron/main/window/window-media.ts
+++ b/src-electron/main/window/window-media.ts
@@ -39,10 +39,6 @@ interface WindowBoundsInfo {
   screenBounds: Electron.Rectangle | undefined;
 }
 
-// =============================================================================
-// HELPER FUNCTIONS - Window State Detection
-// =============================================================================
-
 /**
  * Calculates target display info for automatic positioning
  */
@@ -110,19 +106,26 @@ function calculateAutoTarget(
   return null;
 }
 
+// =============================================================================
+// HELPER FUNCTIONS - Window State Detection
+// =============================================================================
+
 /**
  * Checks and notifies if screen configuration changed
  */
 function checkAndNotifyScreenChange(
   screens: ReturnType<typeof getAllScreens>,
   lastScreensConfig: { value: string },
-): void {
+): boolean {
   const screensConfig = JSON.stringify(screens.map((s) => s.bounds));
 
   if (screensConfig !== lastScreensConfig.value) {
     notifyMainWindowAboutScreenOrWindowChange();
     lastScreensConfig.value = screensConfig;
+    return true;
   }
+
+  return false;
 }
 
 /**
@@ -143,10 +146,6 @@ function findAlternativeScreen(
   return screens.findIndex((s) => !s.mainWindow);
 }
 
-// =============================================================================
-// HELPER FUNCTIONS - Screen Selection
-// =============================================================================
-
 /**
  * Determines the state properties for the media window
  */
@@ -166,6 +165,10 @@ function getMediaWindowState(
     shouldBeMaximizable,
   };
 }
+
+// =============================================================================
+// HELPER FUNCTIONS - Screen Selection
+// =============================================================================
 
 /**
  * Gets the preferred screen from saved preferences
@@ -276,6 +279,22 @@ function normalizeWindowBounds(
   return { height, width, x, y };
 }
 
+function shouldKeepWindowedWithoutExplicitTarget(
+  displayNr: number | undefined,
+  fullscreen: boolean | undefined,
+  isEffectivelyFullscreen: boolean,
+  initialPositioningComplete: boolean,
+  screenConfigChanged: boolean,
+): boolean {
+  const hasExplicitTarget = displayNr !== undefined && fullscreen !== undefined;
+  return (
+    !hasExplicitTarget &&
+    !isEffectivelyFullscreen &&
+    initialPositioningComplete &&
+    !screenConfigChanged
+  );
+}
+
 /**
  * Determines if the window should move to fullscreen on another display
  */
@@ -371,6 +390,7 @@ export const __testables = {
   getTargetWhenOnMainScreen,
   isWindowEffectivelyFullscreen,
   normalizeWindowBounds,
+  shouldKeepWindowedWithoutExplicitTarget,
   shouldMoveWindowedToFullscreen,
   validateAndAdjustTarget,
 };
@@ -398,7 +418,10 @@ export const moveMediaWindow = (displayNr?: number, fullscreen?: boolean) => {
 
     const screens = getAllScreens();
     const lastScreensConfigRef = { value: lastScreensConfig };
-    checkAndNotifyScreenChange(screens, lastScreensConfigRef);
+    const screenConfigChanged = checkAndNotifyScreenChange(
+      screens,
+      lastScreensConfigRef,
+    );
     lastScreensConfig = lastScreensConfigRef.value;
 
     // Get current window state
@@ -435,8 +458,30 @@ export const moveMediaWindow = (displayNr?: number, fullscreen?: boolean) => {
 
     // Determine target display and mode
     let targetInfo: null | TargetDisplayInfo = null;
+    const hasExplicitTarget =
+      displayNr !== undefined && fullscreen !== undefined;
 
-    if (displayNr !== undefined && fullscreen !== undefined) {
+    // Keep user-defined windowed size/position when no explicit move request was made.
+    // This prevents unrelated window sync events (e.g. starting a new media item)
+    // from forcing a manually windowed media window back to fullscreen.
+    if (
+      shouldKeepWindowedWithoutExplicitTarget(
+        displayNr,
+        fullscreen,
+        boundsInfo.isEffectivelyFullscreen,
+        hasInitialPositioningHappened,
+        screenConfigChanged,
+      )
+    ) {
+      log(
+        '🔍 [moveMediaWindow] Media window is windowed and no explicit target was provided; keeping current bounds',
+        'electronWindow',
+        'log',
+      );
+      return;
+    }
+
+    if (hasExplicitTarget) {
       // Explicit parameters provided
       targetInfo = { targetDisplayNr: displayNr, targetFullscreen: fullscreen };
     } else {


### PR DESCRIPTION
### Motivation

- Prevent unintended transitions of a manually windowed media window back to fullscreen when no explicit display or fullscreen target is provided. 
- Improve detection of screen configuration changes and use that information to avoid disrupting user window positioning.

### Description

- Add `shouldKeepWindowedWithoutExplicitTarget` helper and expose it via `__testables` to determine when to keep current windowed bounds instead of auto-moving. 
- Change `checkAndNotifyScreenChange` to return a boolean indicating whether the screen configuration changed and wire that into `moveMediaWindow` as `screenConfigChanged`. 
- Update `moveMediaWindow` to early-return and keep current bounds when there is no explicit `displayNr`/`fullscreen` target and `shouldKeepWindowedWithoutExplicitTarget` is true, while preserving existing behavior for explicit targets and auto-calculated targets. 
- Add unit test `keeps windowed media bounds when no explicit display/mode target is provided` in `src-electron/main/__tests__/window-media.test.ts` and include the new helper in `__testables`.

### Testing

- Ran the unit tests covering `src-electron/main/__tests__/window-media.test.ts` with the project's test runner and the test suite passed. 
- The new test verifies various combinations of `displayNr`, `fullscreen`, `isEffectivelyFullscreen`, `initialPositioningComplete`, and `screenConfigChanged` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9e585e6e48331b7cbe347416e96e5)