### PR TITLE
Add reusable PR creator and switch CI workflows to branch+PR flow for bumps and lockfile updates

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -36,7 +36,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      newTag: ${{ steps.version-bump.outputs.newTag }}
+      bumpBranch: ${{ steps.bump-branch.outputs.name }}
     steps:
+      - id: bump-branch
+        name: Set bump branch name
+        run: echo "name=beta-bump-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -50,6 +56,7 @@ jobs:
           tag-prefix: 'v'
           skip-tag: 'true'
           bump-policy: 'last-commit'
+          target-branch: ${{ steps.bump-branch.outputs.name }}
           commit-message: 'chore: bump version to {{version}} [skip ci]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -57,17 +64,28 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.version-bump.outputs.newTag }}
         run: echo "new version $NEW_VERSION"
-    outputs:
-      newTag: ${{ steps.version-bump.outputs.newTag }}
+
+  merge-version-bump:
+    name: Merge version bump branch
+    needs: bump-version
+    uses: ./.github/workflows/pr-creator-and-waiter.yml
+    with:
+      head: ${{ needs.bump-version.outputs.bumpBranch }}
+      title: 'chore: bump version to ${{ needs.bump-version.outputs.newTag }}'
+      body: 'Automated beta version bump for ${{ needs.bump-version.outputs.newTag }}.'
+    secrets: inherit
 
   draft-release:
     name: Draft release
     runs-on: ubuntu-latest
-    needs: bump-version
+    needs: [bump-version, merge-version-bump]
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
       - name: Create draft release
         id: create_release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -10,7 +10,15 @@ jobs:
     if: github.repository == 'sircharlo/meeting-media-manager'
     permissions:
       contents: write
+    outputs:
+      new_version: ${{ steps.bump.outputs.new_version }}
+      draft_exists: ${{ steps.bump.outputs.draft_exists }}
+      bump_branch: ${{ steps.branch.outputs.name }}
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
+      - id: branch
+        name: Set bump branch name
+        run: echo "name=chore/manual-release-bump-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -27,30 +35,45 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Commit and push changes
+      - name: Commit and push bump branch
         if: steps.bump.outputs.draft_exists != 'true'
+        id: commit
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json
           if git diff --staged --quiet; then
             echo "Version is already correct, nothing to commit."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
-            git push origin master
+            git push origin "HEAD:${{ steps.branch.outputs.name }}"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
-    outputs:
-      new_version: ${{ steps.bump.outputs.new_version }}
-      draft_exists: ${{ steps.bump.outputs.draft_exists }}
+
+  merge-version-bump:
+    name: Merge version bump
+    needs: bump-version
+    if: needs.bump-version.outputs.draft_exists != 'true' && needs.bump-version.outputs.has_changes == 'true'
+    uses: ./.github/workflows/pr-creator-and-waiter.yml
+    with:
+      head: ${{ needs.bump-version.outputs.bump_branch }}
+      title: 'chore: bump version to ${{ needs.bump-version.outputs.new_version }}'
+      body: 'Automated manual release version bump for v${{ needs.bump-version.outputs.new_version }}.'
+    secrets: inherit
 
   draft-release:
     name: Draft release
     runs-on: ubuntu-latest
-    needs: bump-version
+    needs: [bump-version, merge-version-bump]
+    if: always() && needs.bump-version.result == 'success' && (needs.merge-version-bump.result == 'success' || needs.merge-version-bump.result == 'skipped')
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
 
       - name: Clear existing draft release assets
         run: |

--- a/.github/workflows/pr-creator-and-waiter.yml
+++ b/.github/workflows/pr-creator-and-waiter.yml
@@ -1,0 +1,92 @@
+name: Create PR, wait, and merge
+
+on:
+  workflow_call:
+    inputs:
+      base:
+        description: Base branch for the pull request
+        required: false
+        type: string
+        default: master
+      head:
+        description: Head branch for the pull request
+        required: true
+        type: string
+      title:
+        description: Pull request title
+        required: true
+        type: string
+      body:
+        description: Pull request body
+        required: false
+        type: string
+        default: Automated pull request
+      merge-method:
+        description: Merge method (merge, squash, rebase)
+        required: false
+        type: string
+        default: squash
+      delete-branch:
+        description: Delete branch after merge
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  create-wait-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Create pull request
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BASE_BRANCH: ${{ inputs.base }}
+          HEAD_BRANCH: ${{ inputs.head }}
+          PR_TITLE: ${{ inputs.title }}
+          PR_BODY: ${{ inputs.body }}
+        run: |
+          set -e
+
+          pr_url=$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$HEAD_BRANCH" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+          )
+
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for pull request checks
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_URL: ${{ steps.create-pr.outputs.url }}
+        run: gh pr checks "$PR_URL" --watch --interval 30
+
+      - name: Merge pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_URL: ${{ steps.create-pr.outputs.url }}
+          MERGE_METHOD: ${{ inputs.merge-method }}
+          DELETE_BRANCH: ${{ inputs.delete-branch }}
+        run: |
+          set -e
+
+          method_flag="--squash"
+          if [ "$MERGE_METHOD" = "merge" ]; then
+            method_flag="--merge"
+          elif [ "$MERGE_METHOD" = "rebase" ]; then
+            method_flag="--rebase"
+          fi
+
+          delete_flag=""
+          if [ "$DELETE_BRANCH" = "true" ]; then
+            delete_flag="--delete-branch"
+          fi
+
+          gh pr merge "$PR_URL" $method_flag $delete_flag

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -9,7 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      lockfile_branch: ${{ steps.branch.outputs.name }}
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
+      - id: branch
+        name: Set lockfile branch name
+        run: echo "name=chore/refresh-lockfile-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -27,14 +33,27 @@ jobs:
       - name: Install dependencies
         run: yarn install --no-immutable
 
-      - name: Commit and push new lockfile
+      - name: Commit and push lockfile branch
+        id: commit
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add yarn.lock
           if git diff --staged --quiet; then
             echo "No changes to yarn.lock, nothing to commit."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: refresh yarn.lock [skip ci]"
-            git push origin master
+            git push origin "HEAD:${{ steps.branch.outputs.name }}"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+  merge-lockfile:
+    name: Merge lockfile update
+    needs: refresh-lockfile
+    if: needs.refresh-lockfile.outputs.has_changes == 'true'
+    uses: ./.github/workflows/pr-creator-and-waiter.yml
+    with:
+      head: ${{ needs.refresh-lockfile.outputs.lockfile_branch }}
+      title: 'chore: refresh yarn.lock'
+      body: 'Automated yarn.lock refresh.'
+    secrets: inherit

--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -10,7 +10,15 @@ on:
 jobs:
   update-notes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      notes_branch: ${{ steps.branch.outputs.name }}
+      has_changes: ${{ steps.commit.outputs.has_changes }}
     steps:
+      - id: branch
+        name: Set notes branch name
+        run: echo "name=chore/update-release-notes-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -23,14 +31,27 @@ jobs:
       - name: Run update script
         run: python scripts/update-release-notes.py
 
-      - name: Commit and push changes
+      - name: Commit and push notes branch
+        id: commit
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add release-notes/en.md
           if git diff --staged --quiet; then
             echo "No changes to commit"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: auto-update release-notes/en.md from CHANGELOG.md"
-            git push
+            git push origin "HEAD:${{ steps.branch.outputs.name }}"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+
+  merge-notes:
+    needs: update-notes
+    if: needs.update-notes.outputs.has_changes == 'true'
+    uses: ./.github/workflows/pr-creator-and-waiter.yml
+    with:
+      head: ${{ needs.update-notes.outputs.notes_branch }}
+      title: 'chore: auto-update release-notes/en.md from CHANGELOG.md'
+      body: 'Automated release notes update from CHANGELOG.md.'
+    secrets: inherit


### PR DESCRIPTION
### Motivation

- Move from direct `master` pushes to branch-based changes and automated PRs so version bumps, lockfile refreshes, and release-note updates can be reviewed and merged via CI. 
- Provide a reusable step to create a PR, wait for checks, and merge so multiple workflows can share the same merge logic. 
- Ensure draft releases are created from the final merged `master` commit and only after bump/merge work completes.

### Description

- Added a new reusable workflow `/.github/workflows/pr-creator-and-waiter.yml` that creates a PR with inputs `head`, `base`, `title`, `body`, waits for checks via `gh pr checks`, and merges using a selectable method. 
- Updated `beta-release.yml` to create a bump branch (`bump-branch` output), drive the bump action to target that branch, expose `newTag` and `bumpBranch` outputs, and add a `merge-version-bump` step that calls the reusable PR workflow; `draft-release` now depends on the merge and checks out `master` explicitly. 
- Updated `manual-release.yml` to create a bump branch, push changes to that branch, expose outputs (`new_version`, `bump_branch`, `draft_exists`, `has_changes`), and add a conditional `merge-version-bump` reusable-workflow call before drafting a release. 
- Updated `refresh-lockfile.yml` and `update-release-notes.yml` to create feature branches for changes, push to those branches, expose branch/has_changes outputs, and add `merge-lockfile` and `merge-notes` jobs that call the reusable PR workflow to open and merge PRs. 
- Replaced direct `git push` to `master` with `git push origin "HEAD:${{ steps.branch.outputs.name }}"` in all modified workflows and added outputs to indicate whether commits were created (`has_changes`). 

### Testing

- No automated tests were executed for these workflow-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec895e4eb083319cc63ffae48ef78d)