### PR TITLE
fix(ci): create bump branch before version action checkout

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -47,6 +47,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+      - name: Create local bump branch
+        run: |
+          git checkout -B "${{ steps.bump-branch.outputs.name }}"
       - name: Automated Version Bump
         id: version-bump
         uses: phips28/gh-action-bump-version@215e27a882516826c59df7f09da8c67d5f375cbd # v11.1.5


### PR DESCRIPTION
### Motivation
- The bump workflow passed a dynamically generated `target-branch` to the version bump action but did not create that branch locally first, causing the action to fail with `fatal: pathspec '<branch>' did not match any file(s) known to git` during checkout.

### Description
- Add a `Create local bump branch` step in `.github/workflows/beta-release.yml` that runs `git checkout -B "${{ steps.bump-branch.outputs.name }}"` immediately after the repository checkout and before the `phips28/gh-action-bump-version` step.

### Testing
- Ran `git diff --check` which passed, committed the change (pre-commit hooks including `prettier` ran successfully), verified repository status with `git status --short`, and confirmed the last commit with `git log -1 --oneline`; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec90b4b04c83318429b9f0deb66077)