### PR TITLE
Handle existing PRs in create-wait-merge workflow

### DIFF
--- a/.github/workflows/pr-creator-and-waiter.yml
+++ b/.github/workflows/pr-creator-and-waiter.yml
@@ -51,12 +51,33 @@ jobs:
         run: |
           set -e
 
-          pr_url=$(gh pr create \
+          set +e
+          create_output=$(gh pr create \
             --base "$BASE_BRANCH" \
             --head "$HEAD_BRANCH" \
             --title "$PR_TITLE" \
             --body "$PR_BODY" \
-          )
+            2>&1)
+          create_status=$?
+          set -e
+
+          if [ "$create_status" -eq 0 ]; then
+            pr_url="$create_output"
+          else
+            pr_url=$(gh pr list \
+              --state open \
+              --base "$BASE_BRANCH" \
+              --head "$HEAD_BRANCH" \
+              --json url \
+              --jq '.[0].url')
+
+            if [ -n "$pr_url" ]; then
+              echo "Found existing pull request for $HEAD_BRANCH -> $BASE_BRANCH: $pr_url"
+            else
+              echo "$create_output"
+              exit "$create_status"
+            fi
+          fi
 
           echo "url=$pr_url" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Motivation
- The reusable `create-wait-merge` job was failing when `gh pr create` returned an error like "a pull request for branch ... already exists", so the workflow needs to be idempotent for repeated runs against the same head/base pair.

### Description
- Capture `gh pr create` output and exit status by running it with `set +e` and `create_output=$(gh pr create ... 2>&1)` and `create_status=$?` before restoring `set -e`.
- If `gh pr create` fails, query the existing open PR with `gh pr list --state open --base "$BASE_BRANCH" --head "$HEAD_BRANCH" --json url --jq '.[0].url'` and use that URL when present.
- If no matching open PR is found, emit the original `gh pr create` output and exit with the original non-zero status so other errors still fail the workflow.
- Changes applied to ` .github/workflows/pr-creator-and-waiter.yml` to implement the above logic.

### Testing
- Ran `git diff -- .github/workflows/pr-creator-and-waiter.yml && git diff --check`, which succeeded.
- Committed changes, during which pre-commit hooks (including `prettier`) ran and completed successfully.
- Loaded the updated workflow file with a Python read to validate the file content, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec92696d6c833194e4c90efb1abb04)