### PR TITLE
Handle PR waiter when PR has no checks

### DIFF
--- a/.github/workflows/pr-creator-and-waiter.yml
+++ b/.github/workflows/pr-creator-and-waiter.yml
@@ -86,7 +86,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_URL: ${{ steps.create-pr.outputs.url }}
-        run: gh pr checks "$PR_URL" --watch --interval 30
+        run: |
+          set +e
+          checks_output=$(gh pr checks "$PR_URL" --watch --interval 30 2>&1)
+          checks_status=$?
+          set -e
+
+          if [ "$checks_status" -ne 0 ] && echo "$checks_output" | grep -q "no checks reported"; then
+            echo "No checks were reported for this PR; continuing to merge."
+            exit 0
+          fi
+
+          echo "$checks_output"
+          exit "$checks_status"
 
       - name: Merge pull request
         env:


### PR DESCRIPTION
### Motivation
- The reusable PR workflow currently fails if `gh pr checks` exits non-zero for branches that have no status checks configured, blocking automated merges.
- Allow PRs with no reported checks to proceed to merge while keeping other error cases visible and failing.

### Description
- Updated the `Wait for pull request checks` step in `.github/workflows/pr-creator-and-waiter.yml` to capture the `gh pr checks` output and exit status instead of failing immediately.
- Added a conditional to treat the specific `no checks reported` message as non-fatal and continue the workflow when that condition is detected.
- Preserved existing behavior for other `gh pr checks` failures by printing the CLI output and returning the original exit code.

### Testing
- Ran `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr-creator-and-waiter.yml"); puts "YAML parsed successfully"'`, which succeeded and confirmed the workflow YAML is valid.
- Attempted to parse with Python using `PyYAML`, but the environment lacked the `yaml` module so that check failed due to missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec937feb588331880acbce4e8f9d38)