### PR TITLE
ci: allow Mergify queue checks to pass when required jobs are neutral/skipped

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,10 +21,22 @@ queue_rules:
   - name: bots
     merge_conditions:
       - -draft
-      - check-success = "build / Lint and test"
-      - check-success = "build / build (ubuntu-latest)"
-      - check-success = "build / build (macos-latest)"
-      - check-success = "build / build (windows-latest)"
+      - or:
+          - check-success = "build / Lint and test"
+          - check-neutral = "build / Lint and test"
+          - check-skipped = "build / Lint and test"
+      - or:
+          - check-success = "build / build (ubuntu-latest)"
+          - check-neutral = "build / build (ubuntu-latest)"
+          - check-skipped = "build / build (ubuntu-latest)"
+      - or:
+          - check-success = "build / build (macos-latest)"
+          - check-neutral = "build / build (macos-latest)"
+          - check-skipped = "build / build (macos-latest)"
+      - or:
+          - check-success = "build / build (windows-latest)"
+          - check-neutral = "build / build (windows-latest)"
+          - check-skipped = "build / build (windows-latest)"
       - or:
           - and: # translations
               - or:
@@ -34,7 +46,7 @@ queue_rules:
           - and: # dependabot
               - author = dependabot[bot]
               - or:
-                  - title ~= ^((chore|build)(\(deps(?:-dev)*\))*:) bump [^\s]+ from ([1-9][\d]*)\..+ 
+                  - title ~= ^((chore|build)(\(deps(?:-dev)*\))*:) bump [^\s]+ from ([1-9][\d]*)\..+
                     to \4\.
                   - title ~= ^((chore|build)(\(deps(-dev)?\))?:) bump the .+ group across .+ updates
 merge_protections_settings:


### PR DESCRIPTION
### Motivation
- Mergify merge queue runs were failing when required GitHub checks reported `neutral` or `skipped` instead of `success`, blocking bot-driven auto-merge flows.
- The change aims to keep protections in place while accepting non-success terminal states that are acceptable for this repository's automated workflows.

### Description
- Updated `.mergify.yml` `queue_rules` to replace individual `check-success` conditions with `or` groups that accept `check-success`, `check-neutral`, or `check-skipped` for each required job (`build / Lint and test`, `build / build (ubuntu-latest)`, `build / build (macos-latest)`, and `build / build (windows-latest)`).
- Preserved the existing translation and dependabot author/title filters and overall `merge_protections_settings`.

### Testing
- Parsed the updated `.mergify.yml` successfully using Ruby with `ruby -e 'require "yaml"; YAML.load_file(".mergify.yml")'` which returned `ok`.
- Attempted to parse with Python `PyYAML` using `python -c 'import yaml; yaml.safe_load(open(".mergify.yml"))'`, but the environment lacks `PyYAML` so that check failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec966403948331bb45a370d26d63b2)