### PR TITLE
Ignore non-blocking Mergify 'Embarked in merge queue' failures in PR waiter

### DIFF
--- a/.github/workflows/pr-creator-and-waiter.yml
+++ b/.github/workflows/pr-creator-and-waiter.yml
@@ -97,6 +97,20 @@ jobs:
             exit 0
           fi
 
+          if [ "$checks_status" -ne 0 ]; then
+            ignored_failure_pattern='^Queue: Embarked in merge queue[[:space:]]+fail([[:space:]]+|$)'
+            real_failures=$(echo "$checks_output" \
+              | awk -F '\t' '$2 == "fail" { print $0 }' \
+              | grep -Ev "$ignored_failure_pattern" \
+              || true)
+
+            if [ -z "$real_failures" ]; then
+              echo "Ignoring non-blocking check failure: Queue: Embarked in merge queue"
+              echo "$checks_output"
+              exit 0
+            fi
+          fi
+
           echo "$checks_output"
           exit "$checks_status"
 


### PR DESCRIPTION
### Motivation

- Prevent the `Create PR, wait, and merge` workflow from treating the transient Mergify status `Queue: Embarked in merge queue` as a blocking failure when `gh pr checks --watch` exits non-zero.

### Description

- Updated ` .github/workflows/pr-creator-and-waiter.yml` in the `Wait for pull request checks` step to detect and ignore the specific `Queue: Embarked in merge queue` failure pattern.
- Added logic that parses `gh pr checks` output, filters failing checks, excludes the ignored pattern, and treats the result as non-failing when no other real failures are present.
- Preserved the existing `no checks reported` bypass and preserved printing of the full `gh pr checks` output for diagnostics.

### Testing

- Applied the patch to ` .github/workflows/pr-creator-and-waiter.yml` and the patch application succeeded.
- Automated pre-commit formatting hooks (`prettier --write`) ran as part of the change and completed successfully.
- Inspected the updated workflow block to confirm the new failure-filtering logic is present and correctly scoped, with no automated CI failures observed during local validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec97be02a483318cb75d4286fa63ff)