### PR TITLE
fix(electron): allow main window close when app is quitting

### DIFF
--- a/src-electron/main/__tests__/window-main.test.ts
+++ b/src-electron/main/__tests__/window-main.test.ts
@@ -8,6 +8,7 @@ const createMediaWindow = vi.fn();
 const cancelAllDownloads = vi.fn();
 const setAppQuitting = vi.fn();
 const setShouldQuit = vi.fn();
+const quitStatus = { isAppQuitting: false, shouldQuit: false };
 
 vi.mock('electron', () => ({
   BrowserWindow: {
@@ -25,6 +26,7 @@ vi.mock('src-electron/main/downloads', () => ({
 }));
 
 vi.mock('src-electron/main/session', () => ({
+  quitStatus,
   setAppQuitting,
   setShouldQuit,
 }));
@@ -44,6 +46,8 @@ describe('window-main', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getAllWindows.mockReturnValue([]);
+    quitStatus.isAppQuitting = false;
+    quitStatus.shouldQuit = false;
   });
 
   it('reuses an existing main window discovered from BrowserWindow.getAllWindows', async () => {
@@ -91,5 +95,65 @@ describe('window-main', () => {
     expect(minimizedWindow.restore).toHaveBeenCalledOnce();
     expect(minimizedWindow.show).toHaveBeenCalledOnce();
     expect(minimizedWindow.focus).toHaveBeenCalledOnce();
+  });
+
+  it('allows main window to close immediately when app is quitting', async () => {
+    const handlers = new Map<
+      string,
+      (event?: { preventDefault: () => void }) => void
+    >();
+    const createdWindow = {
+      on: vi.fn((eventName: string, handler: () => void) => {
+        handlers.set(eventName, handler);
+      }),
+    };
+    createWindow.mockReturnValue(createdWindow);
+
+    const { createMainWindow, mainWindowInfo } =
+      await import('../window/window-main');
+
+    mainWindowInfo.mainWindow = null;
+    createMainWindow();
+
+    const closeHandler = handlers.get('close');
+    expect(closeHandler).toBeTypeOf('function');
+
+    const preventDefault = vi.fn();
+    quitStatus.isAppQuitting = true;
+    closeHandler?.({ preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(cancelAllDownloads).toHaveBeenCalledOnce();
+    expect(closeOtherWindows).toHaveBeenCalledWith(createdWindow);
+  });
+
+  it('prevents accidental close when app is not quitting and close is unauthorized', async () => {
+    const handlers = new Map<
+      string,
+      (event?: { preventDefault: () => void }) => void
+    >();
+    const createdWindow = {
+      on: vi.fn((eventName: string, handler: () => void) => {
+        handlers.set(eventName, handler);
+      }),
+    };
+    createWindow.mockReturnValue(createdWindow);
+
+    const { createMainWindow, mainWindowInfo } =
+      await import('../window/window-main');
+
+    mainWindowInfo.mainWindow = null;
+    createMainWindow();
+
+    const closeHandler = handlers.get('close');
+    expect(closeHandler).toBeTypeOf('function');
+
+    const preventDefault = vi.fn();
+    closeHandler?.({ preventDefault });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(setShouldQuit).toHaveBeenCalledWith(false);
+    expect(sendToWindow).toHaveBeenCalledWith(createdWindow, 'attemptedClose');
+    expect(cancelAllDownloads).not.toHaveBeenCalled();
   });
 });

--- a/src-electron/main/window/window-main.ts
+++ b/src-electron/main/window/window-main.ts
@@ -1,7 +1,11 @@
 import { BrowserWindow } from 'electron';
 import { PLATFORM, PRODUCT_NAME } from 'src-electron/constants';
 import { cancelAllDownloads } from 'src-electron/main/downloads';
-import { setAppQuitting, setShouldQuit } from 'src-electron/main/session';
+import {
+  quitStatus,
+  setAppQuitting,
+  setShouldQuit,
+} from 'src-electron/main/session';
 import {
   closeOtherWindows,
   createWindow,
@@ -61,7 +65,9 @@ export function createMainWindow() {
     mainWindowInfo.mainWindow.on('close', (e) => {
       if (
         mainWindowInfo.mainWindow &&
-        (authorizedClose.authorized || closeAttempts > 2)
+        (authorizedClose.authorized ||
+          quitStatus.isAppQuitting ||
+          closeAttempts > 2)
       ) {
         cancelAllDownloads();
         closeOtherWindows(mainWindowInfo.mainWindow);


### PR DESCRIPTION
### Motivation
- A Sentry report showed a fatal shutdown path during app quit on Linux/Electron where the main-window `close` handler can block shutdown and contribute to a crash (e.g. `electron_browser_main_parts.cc:523: Failed to shutdown`).
- The change aims to ensure app-initiated quits are not blocked by the accidental-close confirmation logic so the process can terminate cleanly.

### Description
- Import and consult `quitStatus` from `src-electron/main/session` in `src-electron/main/window/window-main.ts` and allow the `close` handler to bypass the confirmation when `quitStatus.isAppQuitting` is true. 
- Adjust the `close` guard to check `(authorizedClose.authorized || quitStatus.isAppQuitting || closeAttempts > 2)` so app-quitting behavior is permitted while preserving existing protections.
- Add unit test scaffolding and tests in `src-electron/main/__tests__/window-main.test.ts` to mock `quitStatus` and verify both the quitting and non-quitting close flows behave as expected.

### Testing
- Added tests and attempted to run `yarn run vitest --project electron src-electron/main/__tests__/window-main.test.ts` in this environment. 
- The test run failed to execute in this environment due to a missing project tsconfig (`Tsconfig not found /workspace/meeting-media-manager/.quasar/tsconfig.json`), so no tests were run here; the new tests are present and should pass in CI or a local environment with the full dev setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6eb1e8608331a4c39372bc702d21)