### PR TITLE
Prevent macOS media window fullscreen oscillation

### DIFF
--- a/src-electron/main/window/window-media.ts
+++ b/src-electron/main/window/window-media.ts
@@ -812,6 +812,23 @@ const setWindowPosition = (displayNr?: number, fullscreen = true) => {
 
     const targetScreenBounds = targetDisplay.bounds;
 
+    // Avoid redundant fullscreen transitions, especially on macOS where toggling
+    // can trigger repeated enter/leave loops when move requests are fired often.
+    const currentBounds = mediaWindowInfo.mediaWindow.getBounds();
+    const currentDisplay = screen.getDisplayMatching(currentBounds);
+    const currentDisplayMatchesTarget = currentDisplay.id === targetDisplay.id;
+    const currentIsFullscreen = mediaWindowInfo.mediaWindow.isFullScreen();
+
+    if (fullscreen && currentDisplayMatchesTarget && currentIsFullscreen) {
+      log(
+        '🔍 [setWindowPosition] Already fullscreen on target display, skipping',
+        'electronWindow',
+        'log',
+      );
+      isMovingWindow = false;
+      return;
+    }
+
     const setWindowBounds = (
       bounds: Partial<Electron.Rectangle>,
       fullScreen = false,


### PR DESCRIPTION
### Motivation
- Prevent the media window repeatedly entering/leaving fullscreen on macOS multi-monitor setups where repeated move/sync calls can retrigger fullscreen transitions and create an oscillation loop.

### Description
- Add an early guard in `setWindowPosition` to detect when the media window is already fullscreen on the target display and return early to avoid redundant fullscreen toggles (changed file: `src-electron/main/window/window-media.ts`).

### Testing
- Ran `npm run -s lint`, which failed in this environment due to existing TypeScript/Quasar configuration issues unrelated to this patch (missing generated `.quasar/tsconfig.json` and module resolution errors), so no repository-wide unit tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f5c6f6908331af825127d392e8e7)