### PR TITLE
Fix PDF multi-page selection import in publication media dialog

### DIFF
--- a/src/components/dialog/DialogPublicationMedia.vue
+++ b/src/components/dialog/DialogPublicationMedia.vue
@@ -1142,15 +1142,12 @@ async function importPdfVersion() {
       tempDir,
       selectedPages,
     );
-    const filteredImages = convertedImages.filter((_, index) =>
-      selectedPages.has(index),
-    );
     globalThis.dispatchEvent(
       new CustomEvent<{
         files: (File | string)[];
         section: MediaSectionIdentifier | undefined;
       }>('localFiles-browsed', {
-        detail: { files: filteredImages, section: props.section },
+        detail: { files: convertedImages, section: props.section },
       }),
     );
     resetState();


### PR DESCRIPTION
### Motivation
- Fix an import bug where selecting multiple PDF pages (e.g. `1,10,31-32`) only added the first page because the dialog applied a second filter that compared converted-image indices against original PDF page indices while `convertPdfToImages` already respected the requested `pages` set.

### Description
- Remove the redundant post-conversion filter and dispatch the full `convertedImages` array directly to the `localFiles-browsed` event in `src/components/dialog/DialogPublicationMedia.vue`, so all selected pages returned by `convertPdfToImages` are imported.

### Testing
- Ran `npx eslint src/components/dialog/DialogPublicationMedia.vue` and the pre-commit formatting/lint hooks (Prettier + ESLint) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53ad84bec8331a2501bcd9ff60272)