### PR TITLE
fix: prevent LIBRAS pause regression from switching playback source

### DIFF
--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -314,6 +314,7 @@ watch(
     if (newAction !== oldAction) postMediaAction(newAction);
 
     const isPlay = newAction === 'play';
+    const isPause = newAction === 'pause';
     const isSignLang = currentLangObject.value?.isSignLanguage;
 
     // Always show media window when playing
@@ -321,7 +322,7 @@ watch(
 
     // Handle sign language special cases
     if (isSignLang) {
-      if (isPlay) return toggleMediaWindowVisibility(true);
+      if (isPlay || isPause) return toggleMediaWindowVisibility(true);
 
       const cameraId = appSettingsStore.displayCameraId;
       return cameraId


### PR DESCRIPTION
### Motivation
- Pausing sign-language (LIBRAS) media was being treated like a stop action and triggered fallback behavior that hides the media window or switches to the camera, which can reset the media element and cause the playback to jump to 0:00 and auto-play.

### Description
- Update `src/pages/MediaCalendarPage.vue` to explicitly recognize `pause` by adding `isPause` and treating `pause` like `play` for sign-language media so the media window remains visible while paused.
- Prevents the pause action from falling through into the sign-language stop/fallback branch that posts a camera stream or hides the media window.

### Testing
- Ran the project's linter with `npm run -s lint`, which executed but reported unrelated TypeScript/tooling resolution errors in this environment; the lint run did not indicate problems introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d88eaea48331b1cc03697fe27384)