### PR TITLE
Fix camera background visibility when media is stopped

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -534,7 +534,7 @@ const { post: postCameraStream } = useBroadcastChannel<
   name: 'camera-stream',
 });
 
-watch(displayCameraId, (newCameraId) => {
+watchImmediate(displayCameraId, (newCameraId) => {
   if (mediaIsPlaying.value) return;
   postCameraStream(newCameraId);
   if (!newCameraId) {

--- a/src/pages/MediaPlayerPage.vue
+++ b/src/pages/MediaPlayerPage.vue
@@ -11,7 +11,7 @@
   >
     <!-- Base yeartext layer - always visible with black background -->
     <div
-      v-if="fontsSet && !mediaPlayerCustomBackground"
+      v-if="fontsSet && !mediaPlayerCustomBackground && !cameraStreamId"
       class="base-layer"
       :class="{ 'blank-screen': isTransitioning }"
     >
@@ -35,7 +35,7 @@
 
     <!-- Custom background layer - always visible when set -->
     <div
-      v-if="mediaPlayerCustomBackground"
+      v-if="mediaPlayerCustomBackground && !cameraStreamId"
       class="base-layer"
       :class="{ 'blank-screen': isTransitioning }"
     >
@@ -44,6 +44,17 @@
         fit="contain"
         no-spinner
         :src="mediaPlayerCustomBackground"
+      />
+    </div>
+
+    <!-- Camera background layer -->
+    <div v-if="cameraStreamId" class="camera-layer">
+      <video
+        ref="cameraElement"
+        autoplay
+        class="fit-snugly"
+        muted
+        playsinline
       />
     </div>
 
@@ -266,6 +277,7 @@ const mediaElement1 = useTemplateRef<HTMLAudioElement | HTMLVideoElement>(
 const mediaElement2 = useTemplateRef<HTMLAudioElement | HTMLVideoElement>(
   'mediaElement2',
 );
+const cameraElement = useTemplateRef<HTMLVideoElement>('cameraElement');
 
 const videoStreaming = ref(false);
 
@@ -368,7 +380,6 @@ whenever(
       currentMediaElement.value?.pause();
     } else if (newMediaAction === 'play') {
       playMediaElement(oldMediaAction === 'pause');
-      if (cameraStreamId.value) cameraStreamId.value = '';
     }
   },
 );
@@ -954,9 +965,12 @@ watchDeep(
   },
 );
 
-const ensureMediaElementReady = async (maxRetries = 50): Promise<boolean> => {
+const ensureElementReady = async (
+  getter: () => HTMLMediaElement | null | undefined,
+  maxRetries = 50,
+): Promise<boolean> => {
   let timeouts = 0;
-  while (!currentMediaElement.value) {
+  while (!getter()) {
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
@@ -965,6 +979,10 @@ const ensureMediaElementReady = async (maxRetries = 50): Promise<boolean> => {
     }
   }
   return true;
+};
+
+const ensureMediaElementReady = async (maxRetries = 50): Promise<boolean> => {
+  return await ensureElementReady(() => currentMediaElement.value, maxRetries);
 };
 
 const notifyAccessDenied = (isCamera: boolean) => {
@@ -1077,43 +1095,78 @@ watch(
   },
 );
 
-watch(
+watchImmediate(
   () => cameraStreamId.value,
   async (deviceId) => {
-    videoStreaming.value = !!deviceId;
+    log(
+      `🎬 [cameraStreamId] Watcher triggered. DeviceId: ${deviceId}`,
+      'mediaPlayer',
+      'log',
+    );
     if (!deviceId) {
-      if (currentMediaElement.value) {
-        currentMediaElement.value.pause();
-        currentMediaElement.value.srcObject = null;
+      if (cameraElement.value) {
+        cameraElement.value.pause();
+        cameraElement.value.srcObject = null;
       }
-      displayLayer1.value.isLive = false;
-      displayLayer1.value.url = '';
-      postMediaPlayingAction('');
       return;
     }
 
-    // Activate a display layer for camera streaming
-    displayLayer1.value.isLive = true;
-    displayLayer1.value.url = ''; // No URL for streaming, just activate the layer
+    // Wait for the camera element to be available in the DOM (v-if)
+    let retries = 0;
+    while (!cameraElement.value && retries < 60) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      retries++;
+    }
+
+    log(
+      `🎬 [cameraStreamId] Element ready check. Element: ${!!cameraElement.value}, Retries: ${retries}`,
+      'mediaPlayer',
+      'log',
+    );
 
     const stream = await requestStream(true, deviceId);
-    const ready = stream && (await ensureMediaElementReady(10));
+    const ready =
+      !!stream && (await ensureElementReady(() => cameraElement.value, 40));
 
-    if (!stream || !ready || !currentMediaElement.value) {
-      videoStreaming.value = false;
-      if (cameraStreamId.value) cameraStreamId.value = '';
-      displayLayer1.value.isLive = false;
-      displayLayer1.value.url = '';
-      postMediaPlayingAction('');
-      currentMediaElement.value?.pause();
-      if (currentMediaElement.value?.srcObject) {
-        currentMediaElement.value.srcObject = null;
+    if (!stream || !ready || !cameraElement.value) {
+      log(
+        `🎬 [cameraStreamId] Failed to initialize. Stream: ${!!stream}, Ready: ${ready}, Element: ${!!cameraElement.value}`,
+        'mediaPlayer',
+        'warn',
+      );
+      cameraElement.value?.pause();
+      if (cameraElement.value?.srcObject) {
+        cameraElement.value.srcObject = null;
       }
       return;
     }
 
-    currentMediaElement.value.srcObject = stream;
-    playMediaElement(false, true);
+    log('🎬 [cameraStreamId] Setting stream to element', 'mediaPlayer', 'log');
+    cameraElement.value.srcObject = stream;
+    try {
+      await cameraElement.value.play();
+      log('🎬 [cameraStreamId] Camera stream started', 'mediaPlayer', 'log');
+    } catch (e) {
+      errorCatcher(e);
+    }
+  },
+);
+
+// Ensure display layers are not live if no media is playing on startup
+watchImmediate(
+  () => mediaPlayingUrl.value,
+  (url) => {
+    if (!url && !videoStreaming.value) {
+      log(
+        '🎬 [mediaPlayingUrl] No media playing, ensuring layers are not live',
+        'mediaPlayer',
+        'log',
+      );
+      displayLayer1.value.isLive = false;
+      displayLayer2.value.isLive = false;
+    }
   },
 );
 
@@ -1194,6 +1247,7 @@ onBeforeUnmount(() => {
   );
   cleanupMediaElement(mediaElement1.value);
   cleanupMediaElement(mediaElement2.value);
+  cleanupMediaElement(cameraElement.value);
 });
 </script>
 
@@ -1216,6 +1270,16 @@ onBeforeUnmount(() => {
   display: none;
 }
 
+.camera-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+  z-index: 1.5;
+}
+
 .display-layer.is-audio {
   background-color: green;
   opacity: 0 !important;
@@ -1227,13 +1291,13 @@ onBeforeUnmount(() => {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: black;
   opacity: 0;
   transition: opacity 0.3s ease-in-out;
   z-index: 2;
 }
 
 .display-layer.is-live {
+  background-color: black;
   opacity: 1;
   z-index: 3;
 }

--- a/src/pages/MediaPlayerPage.vue
+++ b/src/pages/MediaPlayerPage.vue
@@ -1086,9 +1086,15 @@ watch(
         currentMediaElement.value.pause();
         currentMediaElement.value.srcObject = null;
       }
+      displayLayer1.value.isLive = false;
+      displayLayer1.value.url = '';
       postMediaPlayingAction('');
       return;
     }
+
+    // Activate a display layer for camera streaming
+    displayLayer1.value.isLive = true;
+    displayLayer1.value.url = ''; // No URL for streaming, just activate the layer
 
     const stream = await requestStream(true, deviceId);
     const ready = stream && (await ensureMediaElementReady(10));
@@ -1096,6 +1102,8 @@ watch(
     if (!stream || !ready || !currentMediaElement.value) {
       videoStreaming.value = false;
       if (cameraStreamId.value) cameraStreamId.value = '';
+      displayLayer1.value.isLive = false;
+      displayLayer1.value.url = '';
       postMediaPlayingAction('');
       currentMediaElement.value?.pause();
       if (currentMediaElement.value?.srcObject) {


### PR DESCRIPTION
### Motivation
- The camera-as-background flow could turn the laptop camera on but not show the feed on the media display when no other media was playing because no display layer was explicitly marked live for camera streaming.

### Description
- In `src/pages/MediaPlayerPage.vue` updated the `cameraStreamId` watcher to set `displayLayer1.value.isLive = true` and `displayLayer1.value.url = ''` before requesting and attaching the camera stream so the media layer is activated for camera-as-background.
- The watcher now also clears `displayLayer1.value.isLive` and `displayLayer1.value.url` when `cameraStreamId` becomes falsy or when initializing the stream fails to ensure the layer state is consistent and does not remain stuck.

### Testing
- An attempt to run ESLint on the modified file with `yarn exec eslint -c ./eslint.config.js './src/pages/MediaPlayerPage.vue'` was made but failed due to missing project dependencies (`node_modules` state file) in the environment.
- No unit tests were executed in this environment after the change; the change was committed successfully with `git`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f936e3f89483319805057b7a59c519)