### PR TITLE
Fix AlternativeLanguage mapping for songs

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -199,6 +199,15 @@ export const getJwLangCode = (mepsId?: number): JwLangCode | null => {
   return mepslangs[mepsId] || null;
 };
 
+const getMepsLanguageIndex = (langCode?: '' | JwLangCode) => {
+  if (!langCode) return undefined;
+  const matchingEntry = Object.entries(mepslangs).find(
+    ([, code]) => code === langCode,
+  );
+  if (!matchingEntry) return undefined;
+  return Number(matchingEntry[0]);
+};
+
 export const copyToDatedAdditionalMedia = async (
   filepathToCopy: string,
   section: MediaSectionIdentifier | undefined,
@@ -2362,12 +2371,10 @@ export const getWeMedia = async (lookupDate: Date) => {
     const mergedSongs: MultimediaItem[] = songs
       .map((song, index) => {
         if (!songLangs[index]) return song;
-        const AlternativeLanguage = Object.values(mepslangs).indexOf(
-          songLangs[index],
-        );
+        const AlternativeLanguage = getMepsLanguageIndex(songLangs[index]);
         return {
           ...song,
-          ...(AlternativeLanguage === -1
+          ...(AlternativeLanguage === undefined
             ? {}
             : { AlternativeLanguage: AlternativeLanguage }),
         };


### PR DESCRIPTION
### Motivation
- The previous code used `Object.values(mepslangs).indexOf(...)` which yields an array position rather than the explicit numeric MEPS key, risking mismatches when later resolving `mepslangs[media.AlternativeLanguage]`.

### Description
- Added a helper `getMepsLanguageIndex(langCode?: '' | JwLangCode)` that reverse-maps a language code to its numeric MEPS key via `Object.entries(mepslangs)` and returns `Number(key)` or `undefined`.
- Replaced the `Object.values(...).indexOf(...)` lookup in the song merge logic with `getMepsLanguageIndex(...)` and changed the check to only set `AlternativeLanguage` when a valid index is returned.
- This ensures `AlternativeLanguage` is the actual MEPS numeric index compatible with downstream lookups like `mepslangs[media.AlternativeLanguage]`.

### Testing
- Ran `yarn run eslint -c ./eslint.config.js src/helpers/jw-media.ts` which completed successfully.
- Pre-commit style/lint hooks (`prettier` and `eslint --fix`) were executed and passed during the change validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfc84ef3c83318f39e4cfbb1c96a1)