### PR TITLE
Fix sign-language song fallback language resolution

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -2694,27 +2694,19 @@ export async function processMissingMediaInfo({
         mediaHasMepsLanguage(media.MepsLanguageAlternativeIndex) &&
         getJwLangCode(media.MepsLanguageAlternativeIndex);
 
-      // For sign languages, prefer configured fallback over spoken/media-defined defaults.
-      const languageCandidates = isSignLanguage
-        ? [
-            currentStateStore.currentSettings?.lang,
-            currentStateStore.currentSettings?.langFallback,
-            mediaMepsLanguage,
-            mediaAltMepsLanguage,
-          ]
-        : [
-            currentStateStore.currentSettings?.lang,
-            mediaMepsLanguage,
-            mediaAltMepsLanguage,
-            currentStateStore.currentSettings?.langFallback,
-          ];
+      const languageCandidates = [
+        currentStateStore.currentSettings?.lang,
+        mediaMepsLanguage,
+        mediaAltMepsLanguage,
+        currentStateStore.currentSettings?.langFallback,
+      ];
 
       const langsWritten = [...new Set(languageCandidates)].filter(Boolean);
 
       log(
         '[processMissingMediaInfo] Language resolution',
         'mediaProcessing',
-        'info',
+        'debug',
         {
           effectiveMediaKeySymbol,
           fallbackLang: currentStateStore.currentSettings?.langFallback,

--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -2666,32 +2666,64 @@ export async function processMissingMediaInfo({
     );
 
     for (const { media } of mediaToProcess) {
-      /* eslint-disable perfectionist/sort-sets */
-      // Languages to try, in order:
-      const langsWritten = [
-        ...new Set([
-          currentStateStore.currentSettings?.lang, // The language configured in the settings
-          media.MepsLanguageIndex !== undefined &&
-            (!currentStateStore.currentLangObject?.isSignLanguage ||
-              mepsLanguagesByMediaItem?.some(
-                (i) =>
-                  i.KeySymbol === media.KeySymbol &&
-                  i.MepsLanguageIndex === media.MepsLanguageIndex,
-              )) &&
-            getJwLangCode(media.MepsLanguageIndex), // The language defined in the media item
-          media.MepsLanguageAlternativeIndex !== undefined &&
-            media.MepsLanguageAlternativeIndex !== media.MepsLanguageIndex &&
-            (!currentStateStore.currentLangObject?.isSignLanguage ||
-              mepsLanguagesByMediaItem?.some(
-                (i) =>
-                  i.KeySymbol === media.KeySymbol &&
-                  i.MepsLanguageIndex === media.MepsLanguageAlternativeIndex,
-              )) &&
-            getJwLangCode(media.MepsLanguageAlternativeIndex), // The alternative language defined in the media item
-          currentStateStore.currentSettings?.langFallback, // The language fallback configured in the settings
-        ]),
-      ].filter(Boolean);
-      /* eslint-enable perfectionist/sort-sets */
+      const isSignLanguage =
+        !!currentStateStore.currentLangObject?.isSignLanguage;
+      const effectiveMediaKeySymbol =
+        media.KeySymbol === 'sjjm' && isSignLanguage
+          ? currentStateStore.currentSongbook?.pub || media.KeySymbol
+          : media.KeySymbol;
+
+      const mediaHasMepsLanguage = (mepsLanguageIndex?: number) => {
+        if (mepsLanguageIndex === undefined) return false;
+        if (!isSignLanguage) return true;
+
+        return !!mepsLanguagesByMediaItem?.some(
+          (i) =>
+            i.KeySymbol === effectiveMediaKeySymbol &&
+            i.MepsLanguageIndex === mepsLanguageIndex,
+        );
+      };
+
+      const mediaMepsLanguage =
+        mediaHasMepsLanguage(media.MepsLanguageIndex) &&
+        getJwLangCode(media.MepsLanguageIndex);
+      const mediaAltMepsLanguage =
+        media.MepsLanguageAlternativeIndex !== media.MepsLanguageIndex &&
+        mediaHasMepsLanguage(media.MepsLanguageAlternativeIndex) &&
+        getJwLangCode(media.MepsLanguageAlternativeIndex);
+
+      // For sign languages, prefer configured fallback over spoken/media-defined defaults.
+      const languageCandidates = isSignLanguage
+        ? [
+            currentStateStore.currentSettings?.lang,
+            currentStateStore.currentSettings?.langFallback,
+            mediaMepsLanguage,
+            mediaAltMepsLanguage,
+          ]
+        : [
+            currentStateStore.currentSettings?.lang,
+            mediaMepsLanguage,
+            mediaAltMepsLanguage,
+            currentStateStore.currentSettings?.langFallback,
+          ];
+
+      const langsWritten = [...new Set(languageCandidates)].filter(Boolean);
+
+      log(
+        '[processMissingMediaInfo] Language resolution',
+        'mediaProcessing',
+        'info',
+        {
+          effectiveMediaKeySymbol,
+          fallbackLang: currentStateStore.currentSettings?.langFallback,
+          isSignLanguage,
+          keySymbol: media.KeySymbol,
+          langsWritten,
+          mepsLanguageAlternativeIndex: media.MepsLanguageAlternativeIndex,
+          mepsLanguageIndex: media.MepsLanguageIndex,
+          track: media.Track,
+        },
+      );
 
       let mediaWasDownloaded = false;
       const triedPublicationFetchers: PublicationFetcher[] = [];
@@ -2711,6 +2743,13 @@ export async function processMissingMediaInfo({
             media.Track > 0 && { track: media.Track }),
         };
         triedPublicationFetchers.push(publicationFetcher);
+
+        log(
+          '[processMissingMediaInfo] Trying media download',
+          'mediaProcessing',
+          'info',
+          { publicationFetcher },
+        );
 
         if (media.KeySymbol === 'nwt') {
           const pubs = await getBibleMedia(false, langwritten);


### PR DESCRIPTION
### Motivation
- Sign-language congregations (e.g. `LSQ`) sometimes selected an incorrect spoken-language media (e.g. `F`) instead of falling back to the configured spoken fallback (e.g. `ASL`) because MEPS language checks and key-symbol matching were not aligned for `sjjm` song entries.

### Description
- In `processMissingMediaInfo` (`src/helpers/jw-media.ts`) map `sjjm` items to the active songbook symbol when evaluating MEPS language availability so sign-language song entries are matched against the correct key symbol. 
- Add `mediaHasMepsLanguage` and compute `mediaMepsLanguage` / `mediaAltMepsLanguage` using an `effectiveMediaKeySymbol` to ensure MEPS-derived language values are only included when they are relevant for sign-language media. 
- For sign-language congregations change the download-language ordering to try configured `lang` then `langFallback` before media-defined MEPS languages, and de-duplicate into `langsWritten`, to prefer the explicit fallback (e.g. ASL) over unrelated spoken languages. 
- Add detailed tracing logs (`[processMissingMediaInfo] Language resolution` and `[processMissingMediaInfo] Trying media download`) to surface the computed candidate languages and each attempted `PublicationFetcher`, and remove an unused `eslint-disable` directive. 

### Testing
- Ran the linter: `yarn run eslint -c ./eslint.config.js src/helpers/jw-media.ts`, which completed successfully (lint warning fixed during commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc7f1aed88331964f0c1d8347b37d)