### PR TITLE
Avoid circular import by providing getJwLangCode to sqlite via provider

### DIFF
--- a/src/helpers/jw-media.ts
+++ b/src/helpers/jw-media.ts
@@ -3570,4 +3570,5 @@ registerMediaPlaybackProviders({
 
 registerSqliteProviders({
   getDbFromJWPUB,
+  getJwLangCode,
 });

--- a/src/utils/sqlite.ts
+++ b/src/utils/sqlite.ts
@@ -11,7 +11,6 @@ import type {
 const { executeQuery, join } = globalThis.electronApi;
 
 import { errorCatcher } from 'src/helpers/error-catcher';
-import { getJwLangCode } from 'src/helpers/jw-media';
 import { log } from 'src/shared/vanilla';
 import { findFile, getPublicationDirectory } from 'src/utils/fs';
 import { useCurrentStateStore } from 'stores/current-state';
@@ -22,6 +21,8 @@ let getDbFromJWPUBProvider:
       meetingDate?: string,
     ) => Promise<null | string>)
   | null = null;
+let getJwLangCodeProvider: ((mepsId?: number) => JwLangCode | null) | null =
+  null;
 
 /**
  * Registers providers for sqlite utilities to avoid circular dependencies.
@@ -31,8 +32,10 @@ export const registerSqliteProviders = (providers: {
     publication: PublicationFetcher,
     meetingDate?: string,
   ) => Promise<null | string>;
+  getJwLangCode: (mepsId?: number) => JwLangCode | null;
 }) => {
   getDbFromJWPUBProvider = providers.getDbFromJWPUB;
+  getJwLangCodeProvider = providers.getJwLangCode;
 };
 
 const getDbFromJWPUB = async (
@@ -43,6 +46,13 @@ const getDbFromJWPUB = async (
     throw new Error('getDbFromJWPUBProvider not registered');
   }
   return getDbFromJWPUBProvider(publication, meetingDate);
+};
+
+const getJwLangCode = (mepsId?: number) => {
+  if (!getJwLangCodeProvider) {
+    throw new Error('getJwLangCodeProvider not registered');
+  }
+  return getJwLangCodeProvider(mepsId);
 };
 
 export async function addFullFilePathToMultimediaItem(


### PR DESCRIPTION
### Motivation
- Module initialization triggered a circular dependency (`sqlite.ts` -> `jw-media.ts` -> `mediaPlayback.ts`) which caused `TypeError: registerMediaPlaybackProviders is not a function` during test imports.
- The goal is to break that cycle by removing a static import and using a provider registration pattern so initialization order no longer forces cross-module evaluation.

### Description
- Removed the direct `getJwLangCode` import from `src/utils/sqlite.ts` and replaced it with a provider-backed accessor `getJwLangCodeProvider` and a local wrapper `getJwLangCode`.
- Extended `registerSqliteProviders` to accept a `getJwLangCode` provider in addition to `getDbFromJWPUB` and wired the provider into `src/utils/sqlite.ts`.
- Updated `src/helpers/jw-media.ts` to pass `getJwLangCode` when calling `registerSqliteProviders` so `sqlite` can call the function without importing `jw-media` directly.

### Testing
- Running the test suite before the change produced failing imports with `TypeError: registerMediaPlaybackProviders is not a function` (2 test files failed during module import).
- Attempted to run `pnpm test` after the change, but the run was blocked in this environment due to a Node engine mismatch (project requires `^24.14.0`, environment has `v22.22.2`), so automated tests could not be executed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce323cad083319f6ef7d552f41a7f)