### PR TITLE
Extract and reuse regexes for PR links and verse numbers; normalize whitespace in release notes

### DIFF
--- a/scripts/update-release-notes.py
+++ b/scripts/update-release-notes.py
@@ -19,6 +19,8 @@ HEADER = """<!-- markdownlint-disable no-duplicate-heading -->
 For the full list of changes between versions, see our CHANGELOG.md file on GitHub.
 """
 
+PR_LINK_PATTERN = re.compile(r"\(#\d+\)", flags=re.ASCII)
+
 def extract_new_features():
     if not CHANGELOG_PATH.exists():
         print(f"Error: {CHANGELOG_PATH} not found.")
@@ -47,8 +49,9 @@ def extract_new_features():
         if feature_match:
           # Capture the New Features section
             features = feature_match.group(1).strip()
-            # Remove PR links like (#7214)
-            features = re.sub(r'\s*\(#\d+\)', '', features, flags=re.ASCII)
+            # Remove PR links like (#7214) using a linear regex and trim leftover whitespace.
+            features = PR_LINK_PATTERN.sub('', features)
+            features = re.sub(r'[ \t]{2,}', ' ', features, flags=re.ASCII)
             # Append the version header and the extracted features to the output
             output.append(f"\n{version_header}\n\n{features}\n")
 

--- a/src/helpers/mediaPlayback.ts
+++ b/src/helpers/mediaPlayback.ts
@@ -65,6 +65,8 @@ const processMissingMediaInfo: ProcessMissingMediaInfoProvider = (options) => {
   return processMissingMediaInfoProvider(options);
 };
 
+const VERSE_NUMBER_PATTERN = /\b\w+\s+(\d+:\d+|\d+)\b/g;
+
 const {
   basename,
   executeQuery,
@@ -494,7 +496,7 @@ export const getMediaFromJwPlaylist = async (
           .map((v) =>
             Number.parseInt(
               Array.from(
-                v.Label.matchAll(/\w+ ((?:\d+:)?\d+)/g),
+                v.Label.matchAll(VERSE_NUMBER_PATTERN),
                 (m) => m[1],
               )[0] ?? '0',
             ),


### PR DESCRIPTION
### Motivation

- Make regex usage clearer and reusable by extracting commonly used patterns into named constants. 
- Ensure PR link artifacts like `(#7214)` are removed deterministically and leftover spacing is normalized when syncing release notes. 
- Centralize the verse-number matching pattern used when parsing playlist marker labels to reduce duplication and improve readability.

### Description

- Added `PR_LINK_PATTERN` and replaced the inline PR-link `re.sub` with `PR_LINK_PATTERN.sub` in `scripts/update-release-notes.py` and added a follow-up whitespace normalization using `re.sub(r'[ \t]{2,}', ' ', ...)`.
- Introduced `VERSE_NUMBER_PATTERN` in `src/helpers/mediaPlayback.ts` and swapped the previous inline regex in the `matchAll` call to use this constant. 
- Kept existing behavior of extracting the "New Features" section and writing `release-notes/en.md`, with only regex refactors and whitespace cleanup applied.

### Testing

- Ran the TypeScript build with `npm run build` (invokes `tsc`) and the project compiled without errors. 
- Executed the release notes script with `python3 scripts/update-release-notes.py` against the repository `CHANGELOG.md` and it produced the expected `release-notes/en.md` output. 
- Verified the modified parsing in `mediaPlayback.ts` by exercising the playlist parsing path in a local run and confirming verse numbers were still extracted as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf5e68500833182c127941cc71623)