### PR TITLE
Process JW playlist items sequentially to preserve deterministic insertion order

### DIFF
--- a/src/components/dialog/DialogJwPlaylist.vue
+++ b/src/components/dialog/DialogJwPlaylist.vue
@@ -632,8 +632,7 @@ const addSelectedItems = async () => {
 
     const selectedPlaylistItems = selectedItems.value
       .map((i) => playlistItems.value[i])
-      .filter((item): item is NonNullable<typeof item> => !!item)
-      .reverse();
+      .filter((item): item is NonNullable<typeof item> => !!item);
 
     const outputPath = join(
       await getTempPath(),
@@ -642,24 +641,22 @@ const addSelectedItems = async () => {
 
     isProcessing.value = true;
 
-    // 🔥 Process all items *in parallel*
-    const results = await Promise.all(
-      selectedPlaylistItems
-        .filter((item) => !!item)
-        .map((item, idx) => processSingleItem(item, idx, outputPath)),
-    );
-
-    // 🔥 Build MediaItems from results (preserves order)
-    const processedMediaItems = results
-      .sort((a, b) => a.order - b.order)
-      .flatMap((result) => result?.mappedItems || []);
+    // Process items in playlist order so remote-video placeholders and
+    // mapped local items keep deterministic insertion order.
+    const processedMediaItems: DialogImportPayload['items'] = [];
+    for (const [idx, item] of selectedPlaylistItems.entries()) {
+      const result = await processSingleItem(item, idx, outputPath);
+      if (result?.mappedItems?.length) {
+        processedMediaItems.push(...result.mappedItems);
+      }
+    }
 
     // ✅ Always emit processed items - parent handles section assignment
     emit('import', { items: processedMediaItems });
 
     emit('ok');
     log(
-      '✅ All items processed (parallel) and applied (ordered).',
+      '✅ All items processed (sequential) and applied (ordered).',
       'jwPlaylist',
       'info',
     );


### PR DESCRIPTION
### Motivation

- Parallel processing of playlist items led to non-deterministic insertion order for remote-video placeholders and mapped local items.  
- The previous approach used a reverse+sort workaround which was brittle and obscured processing order.

### Description

- Replace parallel `Promise.all` processing with a sequential `for..of` loop that `await`s `processSingleItem` to preserve playlist order.  
- Remove the `.reverse()` call when building `selectedPlaylistItems` and directly push `mappedItems` into a `processedMediaItems` array to maintain deterministic insertion order.  
- Add an explicit type annotation `DialogImportPayload['items']` for `processedMediaItems` and update the log message to reflect sequential processing.  
- Emit `import` with the ordered `processedMediaItems` and keep existing error handling and UI state changes.

### Testing

- Ran the project test suite with `yarn test` and the tests passed.  
- Ran linting with `yarn lint` and there were no new linting errors.  
- Verified that playlist import now produces deterministic item ordering in integration checks (automated import flow assertions passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf5af562483319d3c5eac94eeacf4)