### PR TITLE
fix(ci): inherit secrets for reusable beta workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -76,8 +76,7 @@ jobs:
       head: ${{ needs.bump-version.outputs.bumpBranch }}
       title: 'chore: bump version to ${{ needs.bump-version.outputs.newTag }}'
       body: 'Automated beta version bump for ${{ needs.bump-version.outputs.newTag }}.'
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit
 
   draft-release:
     name: Draft release


### PR DESCRIPTION
### Motivation
- Fix an invalid reusable workflow secret wiring that caused the error `Invalid secret, GITHUB_TOKEN is not defined in the referenced workflow` when calling the internal PR creator workflow from ` .github/workflows/beta-release.yml`.

### Description
- Replace the explicit `GITHUB_TOKEN` mapping with `secrets: inherit` on the `merge-version-bump` reusable workflow call in ` .github/workflows/beta-release.yml` so the callee can access the token as declared.

### Testing
- Ran local repository checks and commands including `sed -n '1,220p' .github/workflows/beta-release.yml`, `sed -n '1,220p' .github/workflows/pr-creator-and-waiter.yml`, `git diff -- .github/workflows/beta-release.yml`, `nl -ba .github/workflows/beta-release.yml | sed -n '70,92p'`, and `git commit -m "fix(ci): inherit secrets for reusable beta workflow"`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda561e6c08331b5cc874b128977f2)