### PR TITLE
Process JW playlist items sequentially and defer remote videos to preserve order

### DIFF
--- a/src/components/dialog/DialogJwPlaylist.vue
+++ b/src/components/dialog/DialogJwPlaylist.vue
@@ -632,8 +632,7 @@ const addSelectedItems = async () => {
 
     const selectedPlaylistItems = selectedItems.value
       .map((i) => playlistItems.value[i])
-      .filter((item): item is NonNullable<typeof item> => !!item)
-      .reverse();
+      .filter((item): item is NonNullable<typeof item> => !!item);
 
     const outputPath = join(
       await getTempPath(),
@@ -642,24 +641,39 @@ const addSelectedItems = async () => {
 
     isProcessing.value = true;
 
-    // 🔥 Process all items *in parallel*
-    const results = await Promise.all(
-      selectedPlaylistItems
-        .filter((item) => !!item)
-        .map((item, idx) => processSingleItem(item, idx, outputPath)),
-    );
+    // Process items in playlist order so remote-video placeholders and
+    // mapped local items keep deterministic insertion order.
+    const processedMediaItems: DialogImportPayload['items'] = [];
+    const deferredVideoItems: {
+      idx: number;
+      item: (typeof selectedPlaylistItems)[number];
+    }[] = [];
 
-    // 🔥 Build MediaItems from results (preserves order)
-    const processedMediaItems = results
-      .sort((a, b) => a.order - b.order)
-      .flatMap((result) => result?.mappedItems || []);
+    for (const [idx, item] of selectedPlaylistItems.entries()) {
+      const isVideo = !item.OriginalFilename;
+      if (isVideo) {
+        deferredVideoItems.push({ idx, item });
+        continue;
+      }
+
+      const result = await processSingleItem(item, idx, outputPath);
+      if (result?.mappedItems?.length) {
+        processedMediaItems.push(...result.mappedItems);
+      }
+    }
+
+    // add placeholders in reverse processing order so top-inserted items keep
+    // the same visible order as the original playlist (1,2,3...)
+    for (const { idx, item } of [...deferredVideoItems].reverse()) {
+      await processSingleItem(item, idx, outputPath);
+    }
 
     // ✅ Always emit processed items - parent handles section assignment
     emit('import', { items: processedMediaItems });
 
     emit('ok');
     log(
-      '✅ All items processed (parallel) and applied (ordered).',
+      '✅ All items processed (sequential) and applied (ordered).',
       'jwPlaylist',
       'info',
     );


### PR DESCRIPTION
### Motivation

- Prevent ordering issues caused by parallel processing so mapped local media and remote-video placeholders keep deterministic insertion order in the playlist import.
- Ensure remote/video items (placeholders) are inserted in a way that preserves the original visible order of the JW playlist.

### Description

- Replace parallel `Promise.all` processing with sequential iteration over `selectedPlaylistItems` and collect mapped local items into `processedMediaItems` via `processSingleItem`.
- Detect video/remote items (where `OriginalFilename` is empty) and defer them into a `deferredVideoItems` array instead of processing immediately.
- After local items are processed, iterate `deferredVideoItems` in reverse and call `processSingleItem` for each to insert placeholders while preserving visible order, and update the emitted import payload to use the constructed `processedMediaItems`.
- Update log message to reflect sequential processing and remove the prior `.reverse()` call on the selected items list.

### Testing

- Ran unit tests with `yarn test`, which completed successfully.
- Ran linting with `yarn lint` and a production build with `yarn build`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcf5af562483319d3c5eac94eeacf4)