### PR TITLE
Update meetings API for congregation lookup; add debounced suggestions and language mapping

### DIFF
--- a/src/components/dialog/DialogCongregationLookup.vue
+++ b/src/components/dialog/DialogCongregationLookup.vue
@@ -71,49 +71,15 @@
           </q-item>
           <template
             v-for="congregation in results"
-            :key="congregation.properties.orgGuid"
+            :key="congregation.congregationGuid"
           >
-            <q-item
-              v-if="congregation.properties.schedule.current"
-              clickable
-              @click="selectCongregation(congregation)"
-            >
+            <q-item clickable @click="selectCongregation(congregation)">
               <q-item-section>
                 <q-item-label>
-                  {{ congregation.properties.orgName }}
+                  {{ congregation.name }}
                 </q-item-label>
                 <q-item-label caption>
-                  {{
-                    dateLocale.days[
-                      congregation.properties.schedule.current.midweek
-                        .weekday === 7
-                        ? 0
-                        : congregation.properties.schedule.current.midweek
-                            .weekday
-                    ]
-                  }}
-                  {{ congregation.properties.schedule.current.midweek.time }}
-                  |
-                  {{
-                    dateLocale.days[
-                      congregation.properties.schedule.current.weekend
-                        .weekday === 7
-                        ? 0
-                        : congregation.properties.schedule.current.weekend
-                            .weekday
-                    ]
-                  }}
-                  {{ congregation.properties.schedule.current.weekend.time }}
-                </q-item-label>
-              </q-item-section>
-              <q-item-section side top>
-                <q-item-label caption>
-                  {{
-                    jwLanguages.list?.find(
-                      (l) =>
-                        l.langcode === congregation?.properties?.languageCode,
-                    )?.vernacularName
-                  }}
+                  {{ congregation.formattedName }}
                 </q-item-label>
               </q-item-section>
             </q-item>
@@ -131,21 +97,18 @@
   </BaseDialog>
 </template>
 <script setup lang="ts">
-import type { CongregationLanguage, GeoRecord } from 'src/types';
-
 import { whenever } from '@vueuse/core';
 import BaseDialog from 'components/dialog/BaseDialog.vue';
 import { storeToRefs } from 'pinia';
-import { useLocale } from 'src/composables/useLocale';
-import { locales } from 'src/constants/locales';
 import {
   applyScheduleToSettings,
+  fetchCongregationSuggestions,
   fetchMeetingLocations,
+  getMeetingLanguageMap,
   normalizeSchedule,
 } from 'src/helpers/congregation-schedule';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { log } from 'src/shared/vanilla';
-import { fetchJson } from 'src/utils/api';
 import { useCurrentStateStore } from 'stores/current-state';
 import { useJwStore } from 'stores/jw';
 import { computed, ref } from 'vue';
@@ -154,12 +117,10 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 
 const jwStore = useJwStore();
-const { jwLanguages, urlVariables } = storeToRefs(jwStore);
+const { jwLanguages } = storeToRefs(jwStore);
 
 const currentState = useCurrentStateStore();
 const { currentSettings } = storeToRefs(currentState);
-
-const { dateLocale } = useLocale();
 
 const props = defineProps<{
   dialogId: string;
@@ -178,94 +139,92 @@ const dialogValue = computed({
 const congregationFilter = ref('');
 const congregationFilterInput = ref();
 const loading = ref(false);
-const results = ref<GeoRecord[]>([]);
+interface CongregationSuggestion {
+  congregationGuid: string;
+  formattedName: string;
+  name: string;
+}
+
+const results = ref<CongregationSuggestion[]>([]);
+const lookupDebounce = ref<null | ReturnType<typeof setTimeout>>(null);
 
 const lookupCongregation = async () => {
-  try {
-    loading.value = true;
-    results.value = [];
-    if (congregationFilter.value?.length > 2) {
-      const response = await fetchMeetingLocations(congregationFilter.value);
-      results.value = (response?.geoLocationList || []).map((location) => {
-        const languageIsAlreadyGood = !!jwLanguages.value?.list.find(
-          (l) => l.langcode === location.properties.languageCode,
-        );
-        if (!languageIsAlreadyGood) {
-          const match = congregationLookupLanguages.value.find(
-            (l) => l.languageCode === location.properties.languageCode,
-          );
-          if (match?.writtenLanguageCode.length) {
-            const appLocaleCodes = new Set(locales.map((l) => l.langcode));
-            location.properties.languageCode =
-              match.writtenLanguageCode.find((code) =>
-                appLocaleCodes.has(code),
-              ) ||
-              match.writtenLanguageCode[0] ||
-              location.properties.languageCode;
-          }
-        }
-        return location;
-      });
-    } else {
+  if (lookupDebounce.value) clearTimeout(lookupDebounce.value);
+  lookupDebounce.value = setTimeout(async () => {
+    try {
+      loading.value = true;
       results.value = [];
+      if (congregationFilter.value?.length > 2) {
+        results.value = await fetchCongregationSuggestions(
+          congregationFilter.value,
+        );
+      } else {
+        results.value = [];
+      }
+    } catch (error) {
+      errorCatcher(error);
+      results.value = [];
+    } finally {
+      loading.value = false;
     }
-  } catch (error) {
-    errorCatcher(error);
-    results.value = [];
-  } finally {
-    loading.value = false;
-  }
+  }, 500);
 };
 
-const congregationLookupLanguages = ref<CongregationLanguage[]>([]);
-
-const loadLanguages = async () => {
-  try {
-    congregationLookupLanguages.value =
-      (await fetchJson<CongregationLanguage[]>(
-        `https://apps.${urlVariables.value.base || 'jw.org'}/api/public/meeting-search/languages`,
-        undefined,
-        useCurrentStateStore().online,
-      )) || [];
-  } catch (error) {
-    errorCatcher(error, {
-      contexts: {
-        fn: {
-          name: 'DialogCongregationLookup.vue',
-          subroutine: 'loadLanguages',
-        },
-      },
-    });
-    congregationLookupLanguages.value = [];
-  }
-};
-
-loadLanguages();
-
-const selectCongregation = (congregation: GeoRecord) => {
+const selectCongregation = async (congregation: CongregationSuggestion) => {
   try {
     if (!currentSettings.value) return;
 
     currentState.lookupInProgress = true;
-    const { properties } = congregation;
+    const response = await fetchMeetingLocations(congregation.congregationGuid);
+    const selectedLocation = response?.items?.find((location) =>
+      location.congregationMeetings.some(
+        (meeting) => meeting.name === congregation.name,
+      ),
+    );
+    if (!selectedLocation) return;
+    const selectedMeeting = selectedLocation.congregationMeetings.find(
+      (meeting) => meeting.name === congregation.name,
+    );
+    if (!selectedMeeting) return;
 
     // Language
-    if (properties.languageCode) {
+    if (selectedMeeting.languageGuid) {
+      const languageMap = await getMeetingLanguageMap();
+      const mappedLanguageCode =
+        languageMap.get(selectedMeeting.languageGuid) || '';
       const resolvedLangCode =
-        jwLanguages.value?.list.find(
-          (l) => l.langcode === properties.languageCode,
-        )?.langcode || '';
+        jwLanguages.value?.list.find((l) => l.langcode === mappedLanguageCode)
+          ?.langcode || '';
       currentSettings.value.lang = resolvedLangCode || 'E';
       currentSettings.value.langSubtitles = resolvedLangCode || null;
     }
 
     // Schedule
-    const normalized = normalizeSchedule(properties.schedule);
+    const normalized = normalizeSchedule({
+      changeStamp: null,
+      current: {
+        midweek: {
+          time: selectedMeeting.midweekMeetingTime.slice(
+            0,
+            5,
+          ) as `${number}:${number}`,
+          weekday: selectedMeeting.midweekMeetingDay + 1,
+        },
+        weekend: {
+          time: selectedMeeting.weekendMeetingTime.slice(
+            0,
+            5,
+          ) as `${number}:${number}`,
+          weekday: selectedMeeting.weekendMeetingDay + 1,
+        },
+      },
+      future: null,
+      futureDate: null,
+    });
     applyScheduleToSettings(currentSettings.value, normalized);
 
-    // Congregation name
-    if (properties.orgName) {
-      currentSettings.value.congregationName = properties.orgName;
+    if (congregation.name) {
+      currentSettings.value.congregationName = congregation.name;
       currentSettings.value.congregationNameModified = false;
     }
   } catch (error) {

--- a/src/helpers/congregation-schedule.ts
+++ b/src/helpers/congregation-schedule.ts
@@ -1,5 +1,7 @@
 import type {
-  GeoRecord,
+  CongregationSearchResult,
+  MeetingLanguage,
+  MeetingSearchResponse,
   NormalizedSchedule,
   ScheduleDetails,
   SettingsValues,
@@ -12,9 +14,27 @@ import { log } from 'src/shared/vanilla';
 import { fetchJson } from 'src/utils/api';
 import { isInPast } from 'src/utils/date';
 import { useCurrentStateStore } from 'stores/current-state';
-import { useJwStore } from 'stores/jw';
 
 import { errorCatcher } from './error-catcher';
+
+let meetingLanguagesPromise: null | Promise<Map<string, string>> = null;
+
+export const getMeetingLanguageMap = async () => {
+  if (!meetingLanguagesPromise) {
+    meetingLanguagesPromise = (async () => {
+      const languages =
+        (await fetchJson<MeetingLanguage[]>(
+          'https://hub.jw.org/meetings/api/languages',
+          undefined,
+          useCurrentStateStore().online,
+        )) || [];
+      return new Map(
+        languages.map((language) => [language.languageGuid, language.code]),
+      );
+    })();
+  }
+  return meetingLanguagesPromise;
+};
 
 export const normalizeSchedule = (
   schedule: ScheduleDetails,
@@ -138,19 +158,49 @@ export const syncMeetingSchedule = async (force = false) => {
       return false;
     }
 
-    const response = await fetchMeetingLocations(
+    const suggestions = await fetchCongregationSuggestions(
       currentSettings.value.congregationName,
     );
+    const exactMatch = suggestions.find(
+      (result) =>
+        result.name.toLowerCase() ===
+        currentSettings.value?.congregationName?.toLowerCase(),
+    );
+    if (!exactMatch) return false;
+    const response = await fetchMeetingLocations(exactMatch.congregationGuid);
 
-    const congregationOnlineInfo = response?.geoLocationList?.find(
-      (loc) =>
-        loc.properties.orgName === currentSettings.value?.congregationName,
+    const congregationOnlineInfo = response?.items?.find((item) =>
+      item.congregationMeetings.some(
+        (meeting) => meeting.name === currentSettings.value?.congregationName,
+      ),
     );
 
     if (congregationOnlineInfo) {
-      const normalized = normalizeSchedule(
-        congregationOnlineInfo.properties.schedule,
+      const selectedMeeting = congregationOnlineInfo.congregationMeetings.find(
+        (meeting) => meeting.name === currentSettings.value?.congregationName,
       );
+      if (!selectedMeeting) return false;
+      const normalized = normalizeSchedule({
+        changeStamp: null,
+        current: {
+          midweek: {
+            time: selectedMeeting.midweekMeetingTime.slice(
+              0,
+              5,
+            ) as `${number}:${number}`,
+            weekday: selectedMeeting.midweekMeetingDay + 1,
+          },
+          weekend: {
+            time: selectedMeeting.weekendMeetingTime.slice(
+              0,
+              5,
+            ) as `${number}:${number}`,
+            weekday: selectedMeeting.weekendMeetingDay + 1,
+          },
+        },
+        future: null,
+        futureDate: null,
+      });
 
       const { currentChanged, futureChanged } = applyScheduleToSettings(
         currentSettings.value,
@@ -189,23 +239,32 @@ export const syncMeetingSchedule = async (force = false) => {
   }
 };
 
-export const fetchMeetingLocations = async (
-  keywords: string,
-): Promise<null | { geoLocationList: GeoRecord[] }> => {
-  const jwStore = useJwStore();
-  const { urlVariables } = jwStore;
-
-  const response = await fetchJson<{ geoLocationList: GeoRecord[] }>(
-    `https://apps.${urlVariables.base || 'jw.org'}/api/public/meeting-search/weekly-meetings`,
+export const fetchCongregationSuggestions = async (keywords: string) =>
+  (await fetchJson<CongregationSearchResult[]>(
+    'https://hub.jw.org/meetings/api/congregations',
     new URLSearchParams({
-      includeSuggestions: 'true',
-      keywords,
-      latitude: '0',
-      longitude: '0',
-      searchLanguageCode: '',
+      congregationName: keywords,
+    }),
+    useCurrentStateStore().online,
+  )) || [];
+
+export const fetchMeetingLocations = async (
+  meetingLocationEventGuid: string,
+): Promise<MeetingSearchResponse | null> => {
+  if (!meetingLocationEventGuid)
+    return { hasResultsOutsideViewport: false, items: [] };
+
+  const details = await fetchJson<MeetingSearchResponse>(
+    'https://hub.jw.org/meetings/api/meeting-search',
+    new URLSearchParams({
+      first: '20',
+      meetingLocationEventGuid,
     }),
     useCurrentStateStore().online,
   );
 
-  return response;
+  return {
+    hasResultsOutsideViewport: details?.hasResultsOutsideViewport || false,
+    items: details?.items || [],
+  };
 };

--- a/src/migrations/auto-enroll-meeting-sync.ts
+++ b/src/migrations/auto-enroll-meeting-sync.ts
@@ -74,13 +74,12 @@ export const autoEnrollMeetingSync: MigrationFunction = async () => {
         continue;
       }
 
-      const suggestions = await fetchCongregationSuggestions(
-        congregationSettings.congregationName,
-      );
+      const congregationName = congregationSettings.congregationName;
+
+      const suggestions = await fetchCongregationSuggestions(congregationName);
       const exactSuggestion = suggestions.find(
         (suggestion) =>
-          suggestion.name.toLowerCase() ===
-          congregationSettings.congregationName.toLowerCase(),
+          suggestion.name.toLowerCase() === congregationName.toLowerCase(),
       );
       if (!exactSuggestion) continue;
       const response = await fetchMeetingLocations(
@@ -89,7 +88,7 @@ export const autoEnrollMeetingSync: MigrationFunction = async () => {
 
       const exactMatch = response?.items?.some((item) =>
         item.congregationMeetings.some(
-          (meeting) => meeting.name === congregationSettings.congregationName,
+          (meeting) => meeting.name === congregationName,
         ),
       );
 

--- a/src/migrations/auto-enroll-meeting-sync.ts
+++ b/src/migrations/auto-enroll-meeting-sync.ts
@@ -1,5 +1,8 @@
 import { storeToRefs } from 'pinia';
-import { fetchMeetingLocations } from 'src/helpers/congregation-schedule';
+import {
+  fetchCongregationSuggestions,
+  fetchMeetingLocations,
+} from 'src/helpers/congregation-schedule';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { log } from 'src/shared/vanilla';
 import { useCurrentStateStore } from 'src/stores/current-state';
@@ -71,13 +74,23 @@ export const autoEnrollMeetingSync: MigrationFunction = async () => {
         continue;
       }
 
-      const response = await fetchMeetingLocations(
+      const suggestions = await fetchCongregationSuggestions(
         congregationSettings.congregationName,
       );
+      const exactSuggestion = suggestions.find(
+        (suggestion) =>
+          suggestion.name.toLowerCase() ===
+          congregationSettings.congregationName.toLowerCase(),
+      );
+      if (!exactSuggestion) continue;
+      const response = await fetchMeetingLocations(
+        exactSuggestion.congregationGuid,
+      );
 
-      const exactMatch = response?.geoLocationList?.find(
-        (loc) =>
-          loc.properties.orgName === congregationSettings.congregationName,
+      const exactMatch = response?.items?.some((item) =>
+        item.congregationMeetings.some(
+          (meeting) => meeting.name === congregationSettings.congregationName,
+        ),
       );
 
       if (exactMatch) {

--- a/src/types/congregation-lookups.d.ts
+++ b/src/types/congregation-lookups.d.ts
@@ -1,5 +1,18 @@
 import type { JwLangCode } from './jw/lang';
 
+export interface CongRecord {
+  $type?: string;
+  assemblies: unknown[];
+  congregationGroupMeetings: unknown[];
+  congregationMeetings: CongregationMeeting[];
+  conventions: unknown[];
+  distanceFromRequestLocationInMeters?: number;
+  id: string;
+  latitude: number;
+  longitude: number;
+  memorials: unknown[];
+}
+
 export interface CongregationLanguage {
   isSignLanguage: boolean;
   languageCode: JwLangCode;
@@ -8,12 +21,38 @@ export interface CongregationLanguage {
   writtenLanguageCode: JwLangCode[];
 }
 
-export interface GeoRecord {
-  geoId: string;
-  isPrimary: boolean;
-  location: GeoLocation;
-  properties: Properties;
-  type: string;
+export interface CongregationMeeting {
+  $type?: string;
+  address: string;
+  groupMeetings: unknown[];
+  id: string;
+  isPrivateHome: boolean;
+  languageGuid: string;
+  midweekMeetingDay: number;
+  midweekMeetingTime: `${number}:${number}:${number}`;
+  name: string;
+  phoneNumber: string;
+  weekendMeetingDay: number;
+  weekendMeetingTime: `${number}:${number}:${number}`;
+}
+
+export interface CongregationSearchResult {
+  congregationGuid: string;
+  formattedName: string;
+  name: string;
+}
+
+export interface MeetingLanguage {
+  $type?: string;
+  code: JwLangCode;
+  languageGuid: string;
+  name: string;
+}
+
+export interface MeetingSearchResponse {
+  $type?: string;
+  hasResultsOutsideViewport: boolean;
+  items: CongRecord[];
 }
 
 export interface NormalizedSchedule {
@@ -35,11 +74,6 @@ export interface NormalizedSchedule {
 interface DaySchedule {
   time: `${number}:${number}`;
   weekday: number;
-}
-
-interface GeoLocation {
-  latitude: number;
-  longitude: number;
 }
 
 interface PhoneDetails {


### PR DESCRIPTION
### Motivation
- Move congregation lookup from the legacy apps API to the Hub meetings API and simplify the data model for suggestions and meeting details.
- Improve UX by debouncing lookups and returning simpler suggestion entries to render in the dialog.
- Ensure schedule and language mapping are resolved from the new meeting response shapes so settings can be applied correctly.

### Description
- Introduce new types for Hub responses: `CongregationSearchResult`, `CongRecord`, `CongregationMeeting`, `MeetingLanguage`, and `MeetingSearchResponse` in `src/types/congregation-lookups.d.ts`.
- Add `fetchCongregationSuggestions` and `getMeetingLanguageMap` helpers and adapt `fetchMeetingLocations` to call the Hub meeting-search endpoint and return a normalized response in `src/helpers/congregation-schedule.ts`.
- Update schedule normalization/use to construct `ScheduleDetails` from `congregationMeetings` (extracting weekday/time and slicing time strings) and map meeting language GUIDs to JW language codes before applying settings.
- Replace the previous complex `GeoRecord` UI rendering with a simpler `CongregationSuggestion` structure, add debounced lookup logic (500ms) and wire suggestion selection to fetch meeting details in `DialogCongregationLookup.vue`.
- Remove old language lookup code and adapt `autoEnrollMeetingSync` migration to use suggestions for exact-match detection before fetching meeting locations.
- Minor import and variable adjustments to accommodate the new helpers and types.

### Testing
- Ran TypeScript type checking and the project's unit test suite; all checks passed.
- Ran the linting/type build step; it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ee44fce0833181b805503cd6fa0d)