### PR TITLE
Auto-hide media window after playback when initially hidden

### DIFF
--- a/src/components/media/MediaItem.vue
+++ b/src/components/media/MediaItem.vue
@@ -1113,6 +1113,7 @@ import { FOOTNOTE_TARGET_PARAGRAPH } from 'src/constants/jw';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { getThumbnailUrl } from 'src/helpers/fs';
 import { toggleMediaWindowVisibility } from 'src/helpers/mediaPlayback';
+import { triggerMediaWindowAutoHide } from 'src/helpers/mediaWindowAutoHide';
 import { triggerZoomScreenShare } from 'src/helpers/zoom';
 import { log, throttleWithTrailing, uuid } from 'src/shared/vanilla';
 import { isFileUrl } from 'src/utils/fs';
@@ -1397,7 +1398,8 @@ const setMediaPlaying = async (
   marker?: VideoMarker,
 ) => {
   if (!mediaPlaying.value.url) {
-    // Start Zoom screen sharing when media starts playing and no media was playing before
+    // Start one-shot workflows when media starts playing and no media was playing before
+    triggerMediaWindowAutoHide(true);
     triggerZoomScreenShare(true);
   } else if (isImage(mediaPlaying.value.url)) {
     stopMedia(true);
@@ -1713,7 +1715,8 @@ function stopMedia(forOtherMediaItem = false) {
   postPlaybackRate(1);
 
   if (!forOtherMediaItem) {
-    // Stop Zoom screen sharing when media is stopped (unless it's a media switch instead of a stop)
+    // Stop one-shot workflows when media is stopped (unless it's a media switch instead of a stop)
+    triggerMediaWindowAutoHide(false);
     triggerZoomScreenShare(false);
     nextTick(() => {
       globalThis.dispatchEvent(new CustomEvent<undefined>('shortcutMediaNext'));

--- a/src/helpers/mediaWindowAutoHide.ts
+++ b/src/helpers/mediaWindowAutoHide.ts
@@ -1,3 +1,4 @@
+import { i18n } from 'boot/i18n';
 import { errorCatcher } from 'src/helpers/error-catcher';
 import { log } from 'src/shared/vanilla';
 import { useCurrentStateStore } from 'stores/current-state';
@@ -15,12 +16,16 @@ const showAutoHiddenNotification = () => {
         handler: () => {
           toggleMediaWindowVisibility(true);
         },
-        label: 'Show media window',
+        label: (i18n.global.t as (key: string) => string)('show-media-display'),
       },
     ],
-    caption:
-      'You can show the media window manually from the Display menu or by clicking the “Show media window” button.',
-    message: 'Media window automatically hidden',
+    caption: (i18n.global.t as (key: string) => string)(
+      'media-window-auto-hidden-caption',
+    ),
+    group: 'mediaWindowAutoHide',
+    message: (i18n.global.t as (key: string) => string)(
+      'media-window-auto-hidden-message',
+    ),
     timeout: 10000,
     type: 'info',
   });

--- a/src/helpers/mediaWindowAutoHide.ts
+++ b/src/helpers/mediaWindowAutoHide.ts
@@ -1,0 +1,63 @@
+import { errorCatcher } from 'src/helpers/error-catcher';
+import { log } from 'src/shared/vanilla';
+import { useCurrentStateStore } from 'stores/current-state';
+
+import { toggleMediaWindowVisibility } from './mediaPlayback';
+import { createTemporaryNotification } from './notifications';
+
+let shouldAutoHideAfterPlayback = false;
+
+const showAutoHiddenNotification = () => {
+  createTemporaryNotification({
+    actions: [
+      {
+        color: 'white',
+        handler: () => {
+          toggleMediaWindowVisibility(true);
+        },
+        label: 'Show media window',
+      },
+    ],
+    caption:
+      'You can show the media window manually from the Display menu or by clicking the “Show media window” button.',
+    message: 'Media window automatically hidden',
+    timeout: 10000,
+    type: 'info',
+  });
+};
+
+/**
+ * Tracks whether playback temporarily showed a hidden media window and restores
+ * that hidden state when playback fully stops.
+ */
+export const triggerMediaWindowAutoHide = (startPlayback: boolean) => {
+  try {
+    const currentState = useCurrentStateStore();
+
+    if (startPlayback) {
+      shouldAutoHideAfterPlayback = !currentState.mediaWindowVisible;
+      log(
+        ` [Media window] Auto-hide ${shouldAutoHideAfterPlayback ? 'armed' : 'skipped'} for playback`,
+        'mediaPlayback',
+        'log',
+      );
+      return;
+    }
+
+    if (!shouldAutoHideAfterPlayback) return;
+
+    shouldAutoHideAfterPlayback = false;
+
+    if (!currentState.mediaWindowVisible) return;
+
+    toggleMediaWindowVisibility(false);
+    showAutoHiddenNotification();
+  } catch (error) {
+    shouldAutoHideAfterPlayback = false;
+    errorCatcher(error, {
+      contexts: {
+        fn: { name: 'triggerMediaWindowAutoHide', startPlayback },
+      },
+    });
+  }
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -328,6 +328,8 @@
   "media-only": "Media only",
   "media-playback": "Media playback",
   "media-sync": "Media sync",
+  "media-window-auto-hidden-caption": "You can show the media window manually from the Display menu or by clicking the button in this notification.",
+  "media-window-auto-hidden-message": "Media window automatically hidden",
   "mediaAutoExportFolder": "Auto-export folder",
   "mediaAutoExportFolder-explain": "Folder for automatic media exports.",
   "mediaExport": "Media export",

--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -159,6 +159,7 @@ import {
   toggleMediaWindowVisibility,
   unzipJwpub,
 } from 'src/helpers/mediaPlayback';
+import { triggerMediaWindowAutoHide } from 'src/helpers/mediaWindowAutoHide';
 import { createTemporaryNotification } from 'src/helpers/notifications';
 import { updateLastUsedDate } from 'src/helpers/usage';
 import { triggerZoomScreenShare } from 'src/helpers/zoom';
@@ -2263,6 +2264,7 @@ watch(
       );
       if (repeatHandled) return;
 
+      triggerMediaWindowAutoHide(false);
       triggerZoomScreenShare(false);
 
       mediaPlaying.value = {


### PR DESCRIPTION
### Motivation
- Provide a one-shot workflow that restores the media window hidden state when playback completes if the window had been hidden before the user clicked play. 
- Mirror the existing Zoom screen-share workflow entry points so the auto-hide is triggered when playback starts and stopped when playback ends or is manually stopped. 
- Inform the operator that the media window was auto-hidden and offer a quick way to bring it back via a temporary notification.

### Description
- Add `src/helpers/mediaWindowAutoHide.ts` which records whether the media window was hidden at playback start and, on stop, restores the hidden state and shows a temporary notification with a `Show media window` action. 
- Wire the workflow into playback start/stop in `src/components/media/MediaItem.vue` by invoking `triggerMediaWindowAutoHide(true)` when starting and `triggerMediaWindowAutoHide(false)` when stopping. 
- Invoke `triggerMediaWindowAutoHide(false)` in the natural media-end handler in `src/pages/MediaCalendarPage.vue` so video/image end events also restore the hidden state when appropriate. 
- Reuse the existing `createTemporaryNotification` helper to surface the notification and `toggleMediaWindowVisibility` to show/hide the media window.

### Testing
- Ran `yarn eslint -c ./eslint.config.js src/helpers/mediaWindowAutoHide.ts src/components/media/MediaItem.vue src/pages/MediaCalendarPage.vue` and linting completed successfully (auto-fixes applied where appropriate). 
- Ran `yarn vue-tsc --noEmit -p tsconfig.json` with no type errors. 
- Ran unit tests with `yarn test:unit --run` where all test files and tests passed (`29` test files, `239` tests), although the test runner emitted network `ENETUNREACH` / teardown noise from the environment during execution; overall test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8d7917508331908b6a818d657a6b)