### PR TITLE
Refresh media after schedule sync; disable delete during playback; animate display popup positions

### DIFF
--- a/src/components/dialog/DialogDisplayPopup.vue
+++ b/src/components/dialog/DialogDisplayPopup.vue
@@ -169,18 +169,14 @@
                     </q-tooltip>
                     <div
                       v-if="screen.mainWindow && scaledMainWindowRect(index)"
+                      class="main-window-rect"
                       :style="{
                         position: 'absolute',
                         left: scaledMainWindowRect(index)?.left + '%',
                         top: scaledMainWindowRect(index)?.top + '%',
                         width: scaledMainWindowRect(index)?.width + '%',
                         height: scaledMainWindowRect(index)?.height + '%',
-                        border: '2px dashed var(--q-primary)',
-                        borderRadius: '4px',
                         pointerEvents: 'none',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
                       }"
                     >
                       <q-icon
@@ -787,6 +783,27 @@ watchImmediate(
 );
 </script>
 <style scoped>
+.screen-rect {
+  transition:
+    left 180ms ease,
+    top 180ms ease,
+    width 180ms ease,
+    height 180ms ease;
+}
+
+.main-window-rect {
+  align-items: center;
+  border: 2px dashed var(--q-primary);
+  border-radius: 4px;
+  display: flex;
+  justify-content: center;
+  transition:
+    left 180ms ease,
+    top 180ms ease,
+    width 180ms ease,
+    height 180ms ease;
+}
+
 .border-dashed::before {
   border-style: dashed;
 }

--- a/src/components/dialog/DialogStudyBible.vue
+++ b/src/components/dialog/DialogStudyBible.vue
@@ -412,7 +412,7 @@ const fetchBibleBookMedia = async () => {
     await fetchChapterMediaAvailability(bibleBook.value);
     allBibleMedia.value = [];
   } else {
-    await fetchMedia();
+    await fetchStudyBibleMedia();
   }
 };
 
@@ -426,7 +426,7 @@ const selectChapter = (chapter: number) => {
   fetchBibleBookMedia();
 };
 
-const fetchMedia = async () => {
+const fetchStudyBibleMedia = async () => {
   try {
     loadingMedia.value = true;
     const result = await getStudyBibleMedia(

--- a/src/components/header/HeaderCalendar.vue
+++ b/src/components/header/HeaderCalendar.vue
@@ -247,6 +247,7 @@
             v-if="additionalMediaForSelectedDayExists"
             v-close-popup
             clickable
+            :disable="mediaIsPlaying"
             @click="mediaDeleteAllPending = true"
           >
             <q-item-section avatar>

--- a/src/helpers/congregation-schedule.ts
+++ b/src/helpers/congregation-schedule.ts
@@ -15,6 +15,7 @@ import { fetchJson } from 'src/utils/api';
 import { isInPast } from 'src/utils/date';
 import { useCurrentStateStore } from 'stores/current-state';
 
+import { updateLookupPeriod } from './date';
 import { errorCatcher } from './error-catcher';
 
 let meetingLanguagesPromise: null | Promise<Map<string, string>> = null;
@@ -233,7 +234,14 @@ export const syncMeetingSchedule = async (force = false) => {
         });
       }
 
-      return currentChanged || futureChanged;
+      const scheduleChanged = currentChanged || futureChanged;
+      if (scheduleChanged) {
+        updateLookupPeriod({ reset: true });
+        const { fetchMedia } = await import('./jw-media');
+        await fetchMedia();
+      }
+
+      return scheduleChanged;
     }
   } catch (error) {
     errorCatcher(error, {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -998,7 +998,7 @@ watch(currentCongregation, async (newCongregation, oldCongregation) => {
 
     const scheduleChanged = !!(await syncMeetingSchedule());
 
-    updateLookupPeriod({ reset: scheduleChanged });
+    if (!scheduleChanged) updateLookupPeriod();
     delayedCacheClear();
 
     if (queues.meetings[newCongregation]) {


### PR DESCRIPTION
### Motivation
- Ensure that when an automatic congregation schedule sync updates meeting times the app immediately refreshes dynamic media so the UI reflects the change without requiring a restart or manual refresh. 
- Prevent deleting all additional media while media is actively playing to avoid accidental removal during presentation. 
- Smooth the visual updates of the screen map and main-window rectangle in the display popup so movements/size changes are not visually janky.

### Description
- When `syncMeetingSchedule` detects an applied schedule change the code now calls `updateLookupPeriod({ reset: true })` and then triggers `fetchMedia()` so dynamic media is refreshed immediately (`src/helpers/congregation-schedule.ts`).
- Avoid a redundant lookup-period reset during congregation startup by updating startup logic to only call `updateLookupPeriod()` when `syncMeetingSchedule` did not already refresh (`src/layouts/MainLayout.vue`).
- Disable the "delete all additional media" menu item while media is playing by adding `:disable="mediaIsPlaying"` to the corresponding `q-item` (`src/components/header/HeaderCalendar.vue`).
- Add CSS transitions and a dedicated class for the main-window rectangle and screen rectangles (`.main-window-rect` and `.screen-rect`) to animate left/top/width/height changes and move inline border styling into the stylesheet for the display popup (`src/components/dialog/DialogDisplayPopup.vue`).

### Testing
- Ran `yarn lint` and auto-fixes were applied; lint completed successfully. 
- Ran unit tests with `yarn test:unit` and all tests passed (29 test files, 239 tests) though the run emitted some network/cleanup noise; overall test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d990a28748331b9e057711c5cb397)