### PR TITLE
Harden profile filename sanitization

### DIFF
--- a/src/utils/__tests__/profile-settings.test.ts
+++ b/src/utils/__tests__/profile-settings.test.ts
@@ -1,0 +1,43 @@
+import { defaultSettings } from 'src/constants/settings';
+import { exportProfileSettingsToFile } from 'src/utils/profile-settings';
+import { describe, expect, it, vi } from 'vitest';
+
+const exportSettings = {
+  ...defaultSettings,
+  congregationName: '  Main Hall / Downtown  ',
+};
+
+describe('profile settings utilities', () => {
+  it('sanitizes the exported filename without regex backtracking risks', async () => {
+    const saveFileDialog = vi
+      .spyOn(globalThis.electronApi, 'saveFileDialog')
+      .mockResolvedValue({ canceled: true });
+
+    await expect(exportProfileSettingsToFile(exportSettings)).resolves.toBe(
+      false,
+    );
+
+    expect(saveFileDialog).toHaveBeenCalledWith(
+      'main-hall-downtown-profile-settings.json',
+      'json',
+    );
+  });
+
+  it('ignores untrusted leading and trailing separators in linear time', async () => {
+    const saveFileDialog = vi
+      .spyOn(globalThis.electronApi, 'saveFileDialog')
+      .mockResolvedValue({ canceled: true });
+
+    await expect(
+      exportProfileSettingsToFile({
+        ...exportSettings,
+        congregationName: `${'-'.repeat(10_000)}A${'!'.repeat(10_000)}`,
+      }),
+    ).resolves.toBe(false);
+
+    expect(saveFileDialog).toHaveBeenCalledWith(
+      'a-profile-settings.json',
+      'json',
+    );
+  });
+});

--- a/src/utils/__tests__/profile-settings.test.ts
+++ b/src/utils/__tests__/profile-settings.test.ts
@@ -11,7 +11,10 @@ describe('profile settings utilities', () => {
   it('sanitizes the exported filename without regex backtracking risks', async () => {
     const saveFileDialog = vi
       .spyOn(globalThis.electronApi, 'saveFileDialog')
-      .mockResolvedValue({ canceled: true });
+      .mockResolvedValue({
+        canceled: true,
+        filePath: '',
+      });
 
     await expect(exportProfileSettingsToFile(exportSettings)).resolves.toBe(
       false,
@@ -26,7 +29,10 @@ describe('profile settings utilities', () => {
   it('ignores untrusted leading and trailing separators in linear time', async () => {
     const saveFileDialog = vi
       .spyOn(globalThis.electronApi, 'saveFileDialog')
-      .mockResolvedValue({ canceled: true });
+      .mockResolvedValue({
+        canceled: true,
+        filePath: '',
+      });
 
     await expect(
       exportProfileSettingsToFile({

--- a/src/utils/profile-settings.ts
+++ b/src/utils/profile-settings.ts
@@ -16,11 +16,42 @@ const settingsKeys = Object.keys(defaultSettings) as (keyof SettingsValues)[];
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-const sanitizeFilename = (value: null | string | undefined) =>
-  (value || 'profile')
-    .replace(/[^a-z0-9-_]+/gi, '-')
-    .replace(/^-+|-+$/g, '')
-    .toLowerCase() || 'profile';
+const isProfileFilenameCharacter = (character: string) => {
+  const codePoint = character.codePointAt(0);
+  return (
+    character === '-' ||
+    character === '_' ||
+    (codePoint !== undefined && codePoint >= 48 && codePoint <= 57) ||
+    (codePoint !== undefined && codePoint >= 97 && codePoint <= 122)
+  );
+};
+
+const sanitizeFilename = (value: null | string | undefined) => {
+  const input = value || 'profile';
+  const sanitizedCharacters: string[] = [];
+  let pendingSeparator = false;
+
+  for (const inputCharacter of input) {
+    const character = inputCharacter.toLowerCase();
+
+    if (isProfileFilenameCharacter(character)) {
+      if (character === '-' && sanitizedCharacters.length === 0) continue;
+      if (pendingSeparator && sanitizedCharacters.length > 0) {
+        sanitizedCharacters.push('-');
+      }
+      sanitizedCharacters.push(character);
+      pendingSeparator = false;
+      continue;
+    }
+
+    pendingSeparator = sanitizedCharacters.length > 0;
+  }
+
+  let end = sanitizedCharacters.length;
+  while (end > 0 && sanitizedCharacters[end - 1] === '-') end--;
+
+  return sanitizedCharacters.slice(0, end).join('') || 'profile';
+};
 
 export const normalizeProfileSettings = (value: unknown): SettingsValues => {
   const candidate =


### PR DESCRIPTION
### Motivation
- The previous sanitizer used chained regular expressions (`/[^a-z0-9-_]+/gi` etc.) that can suffer super-linear backtracking and enable a regex-based DoS (S5852) when processing untrusted input.
- Replace the vulnerable approach with a deterministic implementation that guarantees linear-time processing for exported profile filenames.

### Description
- Replaced the regex-based sanitizer with an explicit character scanner in `src/utils/profile-settings.ts`, introducing `isProfileFilenameCharacter` and a linear-time `sanitizeFilename` implementation that lowercases allowed ASCII characters, collapses invalid runs into a single `-`, trims leading/trailing separators, and falls back to `profile`.
- Added a new unit test file `src/utils/__tests__/profile-settings.test.ts` that verifies normal filename sanitization and an adversarial input scenario with long runs of separators to ensure linear-time behavior.
- Kept existing `exportProfileSettingsToFile` usage intact so callers receive the same filename semantics but with a hardened implementation.

### Testing
- Ran linting with `yarn eslint -c ./eslint.config.js src/utils/profile-settings.ts src/utils/__tests__/profile-settings.test.ts` and applied fixes, result: passed.
- Ran unit tests with `yarn vitest --project quasar src/utils/__tests__/profile-settings.test.ts`, result: all tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da9a3aaf0833184204a97130f43f9)