### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,16 @@ jobs:
         if: ${{ inputs.checkout-latest == false }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Node
-        uses: actions/setup-node@v6
+        if: ${{ !inputs.publish-release }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'yarn'
+      - name: Setup Node without cache for release publishing
+        if: ${{ inputs.publish-release }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
       - name: Install X11 development libraries (Linux only)
         if: runner.os == 'Linux'
         run: |
@@ -88,10 +94,16 @@ jobs:
         if: ${{ inputs.checkout-latest == false }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Node
-        uses: actions/setup-node@v6
+        if: ${{ !inputs.publish-release }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'yarn'
+      - name: Setup Node without cache for release publishing
+        if: ${{ inputs.publish-release }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
       - name: Install X11 development libraries (Linux only)
         if: runner.os == 'Linux'
         run: |
@@ -155,7 +167,7 @@ jobs:
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
       - name: Upload artifacts
         if: ${{ !inputs.publish-release }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: M³ test build for ${{ matrix.os == 'macos-latest' && 'macOS' || matrix.os == 'windows-latest' && 'Windows' || 'Linux' }}
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'yarn'
@@ -45,27 +45,25 @@ jobs:
     needs: [quality]
     permissions:
       contents: read
-      pages: write
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'yarn'
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
       - run: yarn install
       - run: yarn quasar prepare
       - run: |
           yarn generate:logos
           yarn docs:build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dist
           path: docs/.vitepress/dist
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs/.vitepress/dist
 
@@ -81,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels
-        uses: actions/labeler@v6
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213
         with:
           sync-labels: true

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.x'
 

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'yarn'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Close stale issues and pull requests
-        uses: actions/stale@v10
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
         with:
           days-before-stale: 30
           days-before-close: 7

--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
### Motivation

- Mitigate cache poisoning and OIDC token exposure risks in CI by preventing untrusted or fork-triggered code from writing/restoring caches shared with release/publish jobs and by scoping `id-token: write` to deploy-only steps.

### Description

- Update `.github/workflows/build.yml` to use the dependency cache only when `publish-release` is false and add an uncached `actions/setup-node` step for release publishing to avoid restoring shared caches during release builds.
- Update `.github/workflows/docs.yml` to remove `id-token: write` from the docs build job and keep OIDC permission only on the `deploy` job, separating token-scoped actions from cache-using build steps.
- Pin multiple mutable `@vN` action references to exact commit SHAs across affected workflows (`build.yml`, `codeql.yml`, `docs.yml`, `labeler.yml`, `manual-release.yml`, `refresh-lockfile.yml`, `stale.yml`, `update-release-notes.yml`) to remove risk from tag-rot and supply-chain tampering.
- Small substitutions: replace `actions/upload-artifact@v7`, `github/codeql-action@v4`, `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `actions/labeler@v6`, `actions/setup-python@v6`, and `actions/stale@v10` with pinned SHAs; also pin `actions/setup-node` in workflows that still use it.

### Testing

- Parsed all workflow YAML files successfully with `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "workflow YAML parsed successfully"'` (passed).
- Ran `go run github.com/rhysd/actionlint/cmd/actionlint@latest` to validate workflow syntax (passed without errors).
- Ran a custom check that no `pull_request_target` workflow writes/restores an Actions cache with `python` script (passed).
- Ran a custom check that no job combines `id-token: write` with a cache restore/write step (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dab7f2d24833198ac3e43aa9f9510)