### PR TITLE
Add release-commits script and integrate into beta release workflow to generate release notes

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,32 +7,45 @@ on:
 
 jobs:
   get-commit:
-    name: Get commit message
+    name: Get release-worthy commits
     runs-on: ubuntu-latest
     if: github.repository == 'sircharlo/meeting-media-manager'
+    permissions:
+      contents: read
     outputs:
-      msg: ${{ steps.set-msg.outputs.msg }}
+      base_ref: ${{ steps.base.outputs.base_ref }}
+      has_commits: ${{ steps.release_commits.outputs.has_commits }}
+      messages: ${{ steps.release_commits.outputs.messages }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: false
-      - id: set-msg
-        name: Set commit message variable
+      - id: base
+        name: Find previous release boundary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          commitMessages=$(git log "$(git describe --tags --abbrev=0)..HEAD" --pretty=format:"%s" --no-merges | grep -Ei '^(feat|fix|chore|perf|docs):|^(fix(es|ed)?|add(s|ed)?|update(s|d)?|remov(e|es|ed)|refactor(s|ed)?|improve(s|d)?|revert(s|ed)?)\b')
-          echo "Raw commit messages:"
-          echo "$commitMessages"
-          commitMessages="${commitMessages//'%'/'%25'}"
-          commitMessages="${commitMessages//$'\n'/'%0A'}"
-          commitMessages="${commitMessages//$'\r'/'%0D'}"
-          echo "msg=${commitMessages}" >> $GITHUB_OUTPUT
+          base_ref=$(
+            gh release list --limit 100 --exclude-drafts --json tagName,isPrerelease,createdAt \
+              --jq '[.[] | select((.isPrerelease == false) or (.tagName | test("-beta\\.")))] | sort_by(.createdAt) | reverse | .[0].tagName // ""'
+          )
+
+          if [ -z "$base_ref" ]; then
+            base_ref=$(git rev-list --max-parents=0 HEAD)
+          fi
+
+          echo "Using $base_ref as the previous release boundary."
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+      - id: release_commits
+        name: Find release-worthy commit messages
+        run: python scripts/release-commits.py --base-ref "${{ steps.base.outputs.base_ref }}" --github-output "$GITHUB_OUTPUT"
 
   bump-version:
     name: Bump version
     needs: get-commit
-    if: ${{ needs.get-commit.outputs.msg != '' && needs.get-commit.outputs.msg != null }}
+    if: ${{ needs.get-commit.outputs.has_commits == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -82,7 +95,7 @@ jobs:
   draft-release:
     name: Draft release
     runs-on: ubuntu-latest
-    needs: [bump-version, merge-version-bump]
+    needs: [get-commit, bump-version, merge-version-bump]
     permissions:
       contents: write
     steps:
@@ -90,6 +103,12 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
+      - name: Generate release notes
+        run: |
+          python scripts/release-commits.py \
+            --base-ref "${{ needs.get-commit.outputs.base_ref }}" \
+            --version "${{ needs.bump-version.outputs.newTag }}" \
+            --notes-file release-notes.md
       - name: Create draft release
         id: create_release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
@@ -99,7 +118,7 @@ jobs:
           commit: 'master'
           draft: true
           prerelease: true
-          generateReleaseNotes: true
+          bodyFile: release-notes.md
     outputs:
       id: ${{ steps.create_release.outputs.id }}
 

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -103,11 +103,11 @@ jobs:
           if [ -f "$CHANGELOG" ]; then
             # Find the line number of the version header
             START_LINE=$(grep -n "^## $VERSION" "$CHANGELOG" | head -n 1 | cut -d: -f1)
-            
+
             if [ -n "$START_LINE" ]; then
               # Find the next version header line number relative to START_LINE
               RELATIVE_NEXT_LINE=$(tail -n +$((START_LINE + 1)) "$CHANGELOG" | grep -n "^## v" | head -n 1 | cut -d: -f1)
-              
+
               if [ -z "$RELATIVE_NEXT_LINE" ]; then
                 # No next version found, take from START_LINE to end of file
                 sed -n "${START_LINE},\$p" "$CHANGELOG" > $OUTPUT

--- a/scripts/release-commits.py
+++ b/scripts/release-commits.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Find release-worthy commits and optionally write release notes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+CONVENTIONAL_PATTERN = re.compile(
+    r"^(?P<type>feat|fix|perf|refactor|revert|chore|deps|depsdev|deps-dev|build)"
+    r"(?:\([^)]*\))?!?:\s*(?P<description>.+)",
+    flags=re.IGNORECASE | re.ASCII,
+)
+LEGACY_PATTERN = re.compile(
+    r"^(fix(?:es|ed)?|add(?:s|ed)?|update(?:s|d)?|remov(?:e|es|ed)|"
+    r"refactor(?:s|ed)?|improve(?:s|d)?|revert(?:s|ed)?)\b",
+    flags=re.IGNORECASE | re.ASCII,
+)
+SKIP_SUBJECT_PATTERN = re.compile(
+    r"^chore(?:\([^)]*\))?: (?:bump version|auto-update release-notes)",
+    flags=re.IGNORECASE | re.ASCII,
+)
+DOC_ONLY_PATHS = (
+    "docs/",
+    "release-notes/",
+)
+DOC_ONLY_FILES = {
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "README.md",
+}
+WORKFLOW_ONLY_PATHS = (
+    ".github/",
+)
+
+
+def run_git(args: list[str]) -> str:
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+
+
+def is_relevant_subject(subject: str) -> bool:
+    if SKIP_SUBJECT_PATTERN.search(subject):
+        return False
+
+    return bool(
+        CONVENTIONAL_PATTERN.search(subject) or LEGACY_PATTERN.search(subject)
+    )
+
+
+def is_doc_or_workflow_only_path(path: str) -> bool:
+    if path in DOC_ONLY_FILES or path.endswith(".md"):
+        return True
+
+    return path.startswith(DOC_ONLY_PATHS) or path.startswith(WORKFLOW_ONLY_PATHS)
+
+
+def commit_touches_relevant_files(commit: str) -> bool:
+    files_output = run_git([
+        "diff-tree",
+        "--no-commit-id",
+        "--name-only",
+        "-r",
+        commit,
+    ])
+    files = [line for line in files_output.splitlines() if line]
+
+    if not files:
+        return True
+
+    return any(not is_doc_or_workflow_only_path(path) for path in files)
+
+
+def get_commit_subject(commit: str) -> str:
+    return run_git(["show", "-s", "--format=%s", commit])
+
+
+def get_release_commits(base_ref: str, head_ref: str) -> list[tuple[str, str]]:
+    rev_range = f"{base_ref}..{head_ref}"
+    output = run_git(["rev-list", "--reverse", "--no-merges", rev_range])
+    commits = [line for line in output.splitlines() if line]
+    release_commits: list[tuple[str, str]] = []
+
+    for commit in commits:
+        subject = get_commit_subject(commit)
+        if is_relevant_subject(subject) and commit_touches_relevant_files(commit):
+            release_commits.append((commit, subject))
+
+    return release_commits
+
+
+def write_notes(
+    notes_path: Path,
+    version: str,
+    base_ref: str,
+    commits: list[tuple[str, str]],
+) -> None:
+    title = f"Release {version}" if version else "Release notes"
+    lines = [f"# {title}", "", f"Changes since `{base_ref}`:", ""]
+
+    if commits:
+        lines.extend(f"- {subject}" for _, subject in commits)
+    else:
+        lines.append("No release-worthy commits found.")
+
+    notes_path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def append_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            if "\n" in value:
+                output.write(
+                    f"{key}<<__release_commits__\n"
+                    f"{value}\n"
+                    "__release_commits__\n"
+                )
+            else:
+                output.write(f"{key}={value}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument("--version", default="")
+    parser.add_argument("--notes-file")
+    parser.add_argument("--github-output")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    commits = get_release_commits(args.base_ref, args.head_ref)
+    messages = "\n".join(subject for _, subject in commits)
+
+    if args.notes_file:
+        write_notes(Path(args.notes_file), args.version, args.base_ref, commits)
+
+    if args.github_output:
+        append_github_output(
+            Path(args.github_output),
+            {
+                "has_commits": "true" if commits else "false",
+                "messages": messages,
+            },
+        )
+
+    if messages:
+        print(messages)
+    else:
+        print("No release-worthy commits found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Improve reliability of beta release generation by accurately selecting release-worthy commits and generating release notes programmatically. 
- Avoid bumping versions for documentation- or workflow-only changes by inspecting changed paths per commit. 
- Use a clear previous-release boundary (latest non-prerelease or beta tag) to compute the commit range for notes.

### Description

- Add `scripts/release-commits.py` to identify release-worthy commits using conventional and legacy patterns, filter out doc/workflow-only changes, and optionally write a `release-notes.md` file and GitHub Actions output variables. 
- Replace inline `git log` parsing in `.github/workflows/beta-release.yml` with two steps: `Find previous release boundary` (uses `gh release list`) and `Find release-worthy commit messages` (calls the new Python script), and expose `base_ref`, `has_commits`, and `messages` outputs. 
- Update version bump conditional to use `needs.get-commit.outputs.has_commits == 'true'` and make `draft-release` depend on `get-commit`, invoking the script to generate `release-notes.md` and passing it to the release action via `bodyFile`. 
- Add minimal permission and checkout adjustments and minor whitespace/logic cleanup in `manual-release.yml` related to extracting `CHANGELOG.md` sections.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ddf021a788331841f104f562a0190)