### PR TITLE
fix(timer): smooth countdown ring rendering

### DIFF
--- a/src/pages/TimerPage.vue
+++ b/src/pages/TimerPage.vue
@@ -4,7 +4,7 @@
     padding
     :style="containerStyles"
   >
-    <transition mode="out-in" name="scale">
+    <transition :name="displayTransitionName">
       <div
         :key="displayKey"
         class="timer-display"
@@ -65,6 +65,7 @@
               pathLength="100"
               r="44"
             />
+            <circle class="analog-countdown__dot" cx="94" cy="50" r="6" />
           </svg>
           <div class="analog-countdown__inner">
             {{ displayTime }}
@@ -152,6 +153,12 @@ const currentDisplayFormat = computed(() => {
 
 const displayKey = computed(
   () => `${currentMode.value}-${currentDisplayFormat.value}`,
+);
+
+const displayTransitionName = computed(() =>
+  currentMode.value === 'clock'
+    ? 'q-transition--jump-right'
+    : 'q-transition--jump-left',
 );
 
 const isCombinedDisplay = computed(
@@ -297,6 +304,7 @@ const countdownRingColor = computed(() => {
 });
 
 const analogCountdownStyles = computed<CSSProperties>(() => {
+  const isFull = countdownProgress.value >= 1;
   const progressPercent = countdownProgress.value * 100;
   const textColor =
     isOvertime.value && timerData.value?.timerOvertimeIndicator
@@ -304,11 +312,9 @@ const analogCountdownStyles = computed<CSSProperties>(() => {
       : timerData.value?.timerTextColor || '#ffffff';
 
   return {
-    '--countdown-progress': `${progressPercent} 100`,
+    '--countdown-progress': isFull ? '100 0' : `${progressPercent} 100`,
     '--countdown-progress-color': countdownRingColor.value,
-    '--countdown-progress-linecap':
-      countdownProgress.value >= 1 ? 'butt' : 'round',
-    '--countdown-progress-opacity': countdownProgress.value > 0 ? '1' : '0',
+    '--countdown-progress-linecap': isFull ? 'butt' : 'round',
     '--countdown-text-color': textColor,
   };
 });
@@ -574,14 +580,17 @@ watch(timerData, (newData) => {
 }
 
 .analog-countdown__progress {
-  opacity: var(--countdown-progress-opacity);
   stroke: var(--countdown-progress-color);
   stroke-dasharray: var(--countdown-progress);
   stroke-linecap: var(--countdown-progress-linecap);
   transition:
-    opacity 200ms ease,
     stroke 700ms ease,
     stroke-dasharray 200ms linear;
+}
+
+.analog-countdown__dot {
+  fill: var(--countdown-progress-color);
+  transition: fill 700ms ease;
 }
 
 .analog-countdown__inner {
@@ -598,21 +607,6 @@ watch(timerData, (newData) => {
   transition: color 700ms ease;
   width: 76%;
   z-index: 1;
-}
-
-.scale-enter-active,
-.scale-leave-active {
-  transition: all 0.5s ease;
-}
-
-.scale-enter-from {
-  opacity: 0;
-  transform: scale(0.8);
-}
-
-.scale-leave-to {
-  opacity: 0;
-  transform: scale(1.2);
 }
 
 @keyframes gentle-blink {

--- a/src/pages/TimerPage.vue
+++ b/src/pages/TimerPage.vue
@@ -44,6 +44,28 @@
           class="analog-countdown"
           :style="analogCountdownStyles"
         >
+          <svg
+            aria-hidden="true"
+            class="analog-countdown__ring"
+            focusable="false"
+            viewBox="0 0 100 100"
+          >
+            <circle
+              class="analog-countdown__track"
+              cx="50"
+              cy="50"
+              fill="none"
+              r="44"
+            />
+            <circle
+              class="analog-countdown__progress"
+              cx="50"
+              cy="50"
+              fill="none"
+              pathLength="100"
+              r="44"
+            />
+          </svg>
           <div class="analog-countdown__inner">
             {{ displayTime }}
           </div>
@@ -275,15 +297,18 @@ const countdownRingColor = computed(() => {
 });
 
 const analogCountdownStyles = computed<CSSProperties>(() => {
-  const progressDegrees = countdownProgress.value * 360;
+  const progressPercent = countdownProgress.value * 100;
   const textColor =
     isOvertime.value && timerData.value?.timerOvertimeIndicator
       ? timerData.value?.timerOvertimeTextColor || '#ff0000'
       : timerData.value?.timerTextColor || '#ffffff';
 
   return {
-    '--countdown-progress': `${progressDegrees}deg`,
+    '--countdown-progress': `${progressPercent} 100`,
     '--countdown-progress-color': countdownRingColor.value,
+    '--countdown-progress-linecap':
+      countdownProgress.value >= 1 ? 'butt' : 'round',
+    '--countdown-progress-opacity': countdownProgress.value > 0 ? '1' : '0',
     '--countdown-text-color': textColor,
   };
 });
@@ -523,15 +548,40 @@ watch(timerData, (newData) => {
 .analog-countdown {
   align-items: center;
   aspect-ratio: 1;
-  background: conic-gradient(
-    var(--countdown-progress-color) var(--countdown-progress),
-    rgba(255, 255, 255, 0.16) 0
-  );
   border-radius: 50%;
   display: flex;
   height: min(62vh, 62vw);
   justify-content: center;
-  transition: background 700ms ease;
+  position: relative;
+}
+
+.analog-countdown__ring {
+  height: 100%;
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+  transform: rotate(-90deg);
+  width: 100%;
+}
+
+.analog-countdown__track,
+.analog-countdown__progress {
+  stroke-width: 12;
+}
+
+.analog-countdown__track {
+  stroke: rgba(255, 255, 255, 0.16);
+}
+
+.analog-countdown__progress {
+  opacity: var(--countdown-progress-opacity);
+  stroke: var(--countdown-progress-color);
+  stroke-dasharray: var(--countdown-progress);
+  stroke-linecap: var(--countdown-progress-linecap);
+  transition:
+    opacity 200ms ease,
+    stroke 700ms ease,
+    stroke-dasharray 200ms linear;
 }
 
 .analog-countdown__inner {
@@ -547,6 +597,7 @@ watch(timerData, (newData) => {
   justify-content: center;
   transition: color 700ms ease;
   width: 76%;
+  z-index: 1;
 }
 
 .scale-enter-active,


### PR DESCRIPTION
### Motivation

- The analog countdown ring used a `conic-gradient` which produced a visibly jagged edge on the pie slice in some cases. 
- The goal is to render a smoother, antialiased countdown edge and avoid a stray dot at zero progress.

### Description

- Replaced the `conic-gradient` fill with an SVG track/progress ring and updated the template in `src/pages/TimerPage.vue` to render two `<circle>` elements for track and progress. 
- Switched the countdown metric from degrees to an SVG dash value and exposed CSS custom properties (`--countdown-progress`, `--countdown-progress-color`, `--countdown-progress-linecap`, `--countdown-progress-opacity`, `--countdown-text-color`) from the `analogCountdownStyles` computed property. 
- Added SVG/CSS rules (`.analog-countdown__ring`, `.analog-countdown__track`, `.analog-countdown__progress`) with stroke-based progress, rounded caps for partial states, opacity handling to hide the dot at zero, `pointer-events: none`, and layering (`z-index`) so the inner time text remains centered. 

### Testing

- Ran `yarn eslint -c ./eslint.config.js src/pages/TimerPage.vue` and the linting completed successfully. 
- Ran the TypeScript check `yarn vue-tsc --noEmit -p tsconfig.json` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de7803a248331ac11f6e1d52d97c6)