### PR TITLE
fix: ignore missing jwpub zip telemetry

### DIFF
--- a/src-electron/main/__tests__/fs.test.ts
+++ b/src-electron/main/__tests__/fs.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mkdirMock = vi.fn();
 const rmMock = vi.fn();
+const statMock = vi.fn();
 const writeFileMock = vi.fn();
 const delayMock = vi.fn(() => Promise.resolve());
 const captureElectronErrorMock = vi.fn();
@@ -9,6 +10,7 @@ const addElectronBreadcrumbMock = vi.fn();
 const uuidMock = vi.fn(() => 'test-uuid');
 const watchMock = vi.fn();
 const sendToWindowMock = vi.fn();
+const yauzlOpenMock = vi.fn();
 
 vi.mock('chokidar', () => ({
   watch: watchMock,
@@ -34,7 +36,7 @@ vi.mock('node:fs', () => ({
 vi.mock('node:fs/promises', () => ({
   mkdir: mkdirMock,
   rm: rmMock,
-  stat: vi.fn(),
+  stat: statMock,
   writeFile: writeFileMock,
 }));
 
@@ -95,7 +97,9 @@ vi.mock('upath', () => {
 });
 
 vi.mock('yauzl', () => ({
-  default: {},
+  default: {
+    open: yauzlOpenMock,
+  },
 }));
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -114,6 +118,7 @@ describe('isUsablePath', () => {
     mkdirMock.mockResolvedValue(undefined);
     writeFileMock.mockResolvedValue(undefined);
     rmMock.mockResolvedValue(undefined);
+    statMock.mockResolvedValue({ size: 1024 });
     delayMock.mockResolvedValue(undefined);
     sendToWindowMock.mockClear();
     setPlatform('linux');
@@ -245,6 +250,98 @@ describe('isUsablePath', () => {
       undefined,
       'pathProbeNetworkWarning',
     );
+  });
+});
+
+describe('getZipEntries', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    statMock.mockResolvedValue({ size: 1024 });
+  });
+
+  it('does not report missing zip files as Electron errors', async () => {
+    const error = new Error('missing zip');
+    (error as Error & { code?: string }).code = 'ENOENT';
+    statMock.mockRejectedValue(error);
+
+    const { getZipEntries } = await import('../fs');
+
+    await expect(getZipEntries('/tmp/missing.jwpub')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+
+    expect(yauzlOpenMock).not.toHaveBeenCalled();
+    expect(addElectronBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'zip',
+        data: expect.objectContaining({
+          errorCode: 'ENOENT',
+          zipPath: '/tmp/missing.jwpub',
+        }),
+        level: 'info',
+        message: 'Zip file unavailable before listing entries',
+      }),
+    );
+    expect(captureElectronErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('reports unexpected stat errors before opening zip files', async () => {
+    const error = new Error('permission denied');
+    (error as Error & { code?: string }).code = 'EACCES';
+    statMock.mockRejectedValue(error);
+
+    const { getZipEntries } = await import('../fs');
+
+    await expect(getZipEntries('/tmp/locked.jwpub')).rejects.toMatchObject({
+      code: 'EACCES',
+    });
+
+    expect(yauzlOpenMock).not.toHaveBeenCalled();
+    expect(captureElectronErrorMock).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        contexts: {
+          fn: {
+            args: { zipPath: '/tmp/locked.jwpub' },
+            name: 'getZipEntries stat',
+          },
+        },
+      }),
+    );
+  });
+
+  it('adds diagnostics but does not report zip files deleted after stat', async () => {
+    const error = new Error('missing after stat');
+    (error as Error & { code?: string }).code = 'ENOENT';
+    yauzlOpenMock.mockImplementation((_path, _options, callback) => {
+      callback(error);
+    });
+
+    const { getZipEntries } = await import('../fs');
+
+    await expect(getZipEntries('/tmp/raced.jwpub')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+
+    expect(yauzlOpenMock).toHaveBeenCalledWith(
+      '/tmp/raced.jwpub',
+      { lazyEntries: true },
+      expect.any(Function),
+    );
+    expect(addElectronBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'zip',
+        data: expect.objectContaining({
+          errorCode: 'ENOENT',
+          fileSize: 1024,
+          zipPath: '/tmp/raced.jwpub',
+        }),
+        level: 'info',
+        message: 'Error opening zip entries',
+      }),
+    );
+    expect(captureElectronErrorMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src-electron/main/fs.ts
+++ b/src-electron/main/fs.ts
@@ -767,19 +767,66 @@ const decompress = async (
 export async function getZipEntries(
   zipPath: string,
 ): Promise<Record<string, number>> {
+  let fileSize = 0;
+
+  try {
+    const stats = await stat(zipPath);
+    fileSize = stats.size;
+  } catch (error) {
+    const errorCode = (error as { code?: string }).code;
+
+    addElectronBreadcrumb({
+      category: 'zip',
+      data: { errorCode, zipPath },
+      level: errorCode === 'ENOENT' ? 'info' : 'error',
+      message: 'Zip file unavailable before listing entries',
+    });
+
+    if (errorCode !== 'ENOENT') {
+      captureElectronError(error, {
+        contexts: {
+          fn: {
+            args: { zipPath },
+            name: 'getZipEntries stat',
+          },
+        },
+      });
+    }
+
+    throw error;
+  }
+
+  addElectronBreadcrumb({
+    category: 'zip',
+    data: { fileSize, zipPath },
+    message: 'Reading zip entries',
+  });
+
   return new Promise((resolve, reject) => {
     const entries: Record<string, number> = {};
 
     yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
       if (err) {
-        captureElectronError(err, {
-          contexts: {
-            fn: {
-              args: { zipPath },
-              name: 'getZipEntries yauzl.open',
-            },
-          },
+        const errorCode = (err as { code?: string }).code;
+
+        addElectronBreadcrumb({
+          category: 'zip',
+          data: { errorCode, fileSize, zipPath },
+          level: errorCode === 'ENOENT' ? 'info' : 'error',
+          message: 'Error opening zip entries',
         });
+
+        if (errorCode !== 'ENOENT') {
+          captureElectronError(err, {
+            contexts: {
+              fn: {
+                args: { fileSize, zipPath },
+                name: 'getZipEntries yauzl.open',
+              },
+            },
+          });
+        }
+
         return reject(err);
       }
       if (!zipfile) return reject(new Error('Zipfile not found'));
@@ -817,14 +864,30 @@ export async function getZipEntries(
       });
 
       zipfile.on('end', () => {
+        addElectronBreadcrumb({
+          category: 'zip',
+          data: {
+            entryCount: fileCount,
+            fileSize,
+            totalUncompressedSize,
+            zipPath,
+          },
+          message: 'Finished reading zip entries',
+        });
         resolve(entries);
       });
 
       zipfile.on('error', (err) => {
+        addElectronBreadcrumb({
+          category: 'zip',
+          data: { fileSize, zipPath },
+          level: 'error',
+          message: 'Zip entry stream error',
+        });
         captureElectronError(err, {
           contexts: {
             fn: {
-              args: { zipPath },
+              args: { fileSize, zipPath },
               name: 'getZipEntries zipfile error',
             },
           },


### PR DESCRIPTION
### Motivation
- Sentry reported `ENOENT` when `getZipEntries` attempted to open a JWPUB that had been removed or never existed; this noise makes it hard to triage real errors while losing lightweight diagnostics about the zip itself.

### Description
- Add a `stat()` preflight to `getZipEntries` in `src-electron/main/fs.ts` and record a zip-specific breadcrumb with `fileSize` and `zipPath` before attempting to open the archive.
- Treat `ENOENT` from the preflight and from `yauzl.open` as expected and emit an info-level breadcrumb instead of sending to Sentry, while still rejecting to the caller; unexpected stat/open/stream errors are captured with richer `fileSize`/`zipPath` context.
- Add breadcrumbs for start/finish/error events around the zip-entry listing so diagnostics are available in Sentry without noisy error reports for missing files.
- Add focused tests in `src-electron/main/__tests__/fs.test.ts` that assert missing-file (`ENOENT`), unexpected `stat` failures, and the race where a file is deleted after `stat()` but before `yauzl.open()` are handled as intended.

### Testing
- Ran `yarn vitest run src-electron/main/__tests__/fs.test.ts --project electron` and the test suite passed (`11 passed`).
- Ran `yarn lint` and fixes completed successfully with no lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed423aedc8331be9cc675acede16e)