### PR TITLE
fix: capture gpu crash diagnostics

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -7,6 +7,7 @@ import {
   type MenuItem,
   type MenuItemConstructorOptions,
   protocol,
+  screen,
   shell,
 } from 'electron';
 import { pathExistsSync, readJsonSync, writeJsonSync } from 'fs-extra/esm';
@@ -77,6 +78,18 @@ initSentry({
         }
       }
 
+      const logFatal = event.contexts?.electron?.LOG_FATAL;
+      if (
+        typeof logFatal === 'string' &&
+        logFatal.includes("GPU process isn't usable")
+      ) {
+        event.contexts = {
+          ...event.contexts,
+          gpuDiagnostic: getGpuDiagnosticSnapshot('sentry-before-send'),
+        };
+        event.tags = { ...event.tags, gpuFatal: 'unusable-gpu-process' };
+      }
+
       const error = event.exception?.values?.[0];
       if (
         error?.value &&
@@ -96,6 +109,65 @@ initSentry({
 });
 
 const gotTheLock = app.requestSingleInstanceLock();
+
+async function captureGpuCrash(
+  type: string,
+  details: Electron.Details | Electron.RenderProcessGoneDetails,
+) {
+  const snapshot = getGpuDiagnosticSnapshot(`${type} process gone`, details);
+  writeGpuDiagnosticSnapshot(snapshot);
+
+  const basicGpuInfo = await getBasicGpuInfo();
+
+  captureException(new Error(`${type} process crashed: ${details.reason}`), {
+    contexts: {
+      gpuDiagnostic: snapshot,
+    },
+    extra: { ...details, gpuInfo: basicGpuInfo },
+    tags: { reason: details.reason, type },
+  });
+}
+
+function configureAppDataPaths() {
+  if (process.env.PORTABLE_EXECUTABLE_DIR) {
+    const portableExecutableDir = resolve(process.env.PORTABLE_EXECUTABLE_DIR);
+    app.setPath('appData', portableExecutableDir);
+    app.setPath(
+      'userData',
+      join(portableExecutableDir, `${PRODUCT_NAME} - User Data`),
+    );
+    app.setPath(
+      'temp',
+      join(portableExecutableDir, `${PRODUCT_NAME} - Temporary Files`),
+    );
+  } else if (IS_TEST && PRODUCT_NAME) {
+    app.setPath('userData', join(app.getPath('appData'), PRODUCT_NAME));
+  }
+}
+
+function configureChromiumGpuDiagnostics() {
+  if (!isTruthyEnvironmentValue(process.env.M3_ENABLE_GPU_DIAGNOSTICS)) return;
+
+  const logFile = join(app.getPath('userData'), 'chromium-gpu.log');
+  app.commandLine.appendSwitch('enable-logging', 'file');
+  app.commandLine.appendSwitch('log-file', logFile);
+  app.commandLine.appendSwitch('log-level', '0');
+  app.commandLine.appendSwitch(
+    'vmodule',
+    'gpu*=2,viz*=2,gl*=2,ui/gl*=2,media/gpu*=2',
+  );
+  log(`Chromium GPU diagnostics enabled at ${logFile}`, 'electron', 'log');
+
+  if (isTruthyEnvironmentValue(process.env.M3_DISABLE_GPU_SANDBOX)) {
+    app.commandLine.appendSwitch('disable-gpu-sandbox');
+    log('GPU sandbox disabled by diagnostics environment', 'electron', 'log');
+  }
+
+  if (isTruthyEnvironmentValue(process.env.M3_IN_PROCESS_GPU)) {
+    app.commandLine.appendSwitch('in-process-gpu');
+    log('In-process GPU enabled by diagnostics environment', 'electron', 'log');
+  }
+}
 
 function createApplicationMenu() {
   const appMenu: MenuItem | MenuItemConstructorOptions = { role: 'appMenu' };
@@ -150,7 +222,130 @@ function createApplicationMenu() {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
+async function getBasicGpuInfo() {
+  try {
+    return await app.getGPUInfo('basic');
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getGpuDiagnosticSnapshot(reason: string, details?: unknown) {
+  return {
+    app: {
+      hardwareAccelerationEnabled: getHardwareAccelerationEnabled(),
+      isReady: app.isReady(),
+      name,
+      version,
+    },
+    details,
+    environment: {
+      desktopSession: process.env.DESKTOP_SESSION,
+      display: process.env.DISPLAY,
+      nodeEnvironment: process.env.NODE_ENV,
+      originalXdgCurrentDesktop: process.env.ORIGINAL_XDG_CURRENT_DESKTOP,
+      waylandDisplay: process.env.WAYLAND_DISPLAY,
+      xdgCurrentDesktop: process.env.XDG_CURRENT_DESKTOP,
+      xdgSessionType: process.env.XDG_SESSION_TYPE,
+    },
+    gpuFeatureStatus: getGpuFeatureStatus(),
+    platform: {
+      arch: process.arch,
+      platform: process.platform,
+      release: process.getSystemVersion(),
+      versions: process.versions,
+    },
+    reason,
+    screens: getScreenDiagnostics(),
+    switches: {
+      disableGpu: app.commandLine.hasSwitch('disable-gpu'),
+      disableGpuSandbox: app.commandLine.hasSwitch('disable-gpu-sandbox'),
+      disableSoftwareRasterizer: app.commandLine.hasSwitch(
+        'disable-software-rasterizer',
+      ),
+      enableLogging: app.commandLine.hasSwitch('enable-logging'),
+      gtkVersion: app.commandLine.getSwitchValue('gtk-version'),
+      inProcessGpu: app.commandLine.hasSwitch('in-process-gpu'),
+      logFile: app.commandLine.getSwitchValue('log-file'),
+      logLevel: app.commandLine.getSwitchValue('log-level'),
+      ozonePlatform: app.commandLine.getSwitchValue('ozone-platform'),
+      useGl: app.commandLine.getSwitchValue('use-gl'),
+      vmodule: app.commandLine.getSwitchValue('vmodule'),
+    },
+    time: new Date().toISOString(),
+  };
+}
+
+function getGpuFeatureStatus() {
+  try {
+    return app.getGPUFeatureStatus();
+  } catch (error) {
+    return { error: getErrorMessage(error) };
+  }
+}
+
+function getHardwareAccelerationEnabled() {
+  try {
+    return app.isHardwareAccelerationEnabled();
+  } catch {
+    return null;
+  }
+}
+
+function getScreenDiagnostics() {
+  try {
+    if (!app.isReady()) return [];
+
+    return screen.getAllDisplays().map((display) => ({
+      bounds: display.bounds,
+      id: display.id,
+      internal: display.internal,
+      label: display.label,
+      scaleFactor: display.scaleFactor,
+      size: display.size,
+      workArea: display.workArea,
+    }));
+  } catch (error) {
+    return [{ error: getErrorMessage(error) }];
+  }
+}
+
+function isTruthyEnvironmentValue(value: string | undefined) {
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
+function readGpuDiagnosticSnapshots() {
+  try {
+    const filePath = getGpuDiagnosticsFilePath();
+    if (!pathExistsSync(filePath)) return [];
+
+    const data = readJsonSync(filePath);
+    return Array.isArray(data) ? data : [];
+  } catch (error) {
+    log('Failed to read GPU diagnostics:', 'electron', 'warn', error);
+    return [];
+  }
+}
+
+function writeGpuDiagnosticSnapshot(
+  snapshot: ReturnType<typeof getGpuDiagnosticSnapshot>,
+) {
+  try {
+    const filePath = getGpuDiagnosticsFilePath();
+    const existing = readGpuDiagnosticSnapshots();
+    writeJsonSync(filePath, [...existing.slice(-19), snapshot], { spaces: 2 });
+  } catch (error) {
+    log('Failed to write GPU diagnostics:', 'electron', 'warn', error);
+  }
+}
+
 if (gotTheLock) {
+  configureAppDataPaths();
+
   // Check for crash loop on startup
   const crashCount = incrementCrashCount();
   log(`Startup crash count: ${crashCount}`, 'electron', 'log');
@@ -178,9 +373,20 @@ if (gotTheLock) {
   if (isHwAccelDisabled()) {
     app.disableHardwareAcceleration();
     log('Hardware acceleration disabled', 'electron', 'log');
+
+    if (PLATFORM === 'linux') {
+      app.commandLine.appendSwitch('disable-gpu-sandbox');
+      log(
+        'GPU sandbox disabled while using hardware-acceleration crash fallback',
+        'electron',
+        'log',
+      );
+    }
   } else {
     log('Hardware acceleration enabled', 'electron', 'log');
   }
+
+  configureChromiumGpuDiagnostics();
 
   app.on('second-instance', () => {
     // Someone tried to run a second instance, we should focus our globalThis.
@@ -192,21 +398,6 @@ if (gotTheLock) {
     app.setAppUserModelId(`${APP_ID}`);
   } else if (PLATFORM === 'linux') {
     app.commandLine.appendSwitch('gtk-version', '3'); // Force GTK 3 on Linux (Workaround for https://github.com/electron/electron/issues/46538)
-  }
-
-  if (process.env.PORTABLE_EXECUTABLE_DIR) {
-    const portableExecutableDir = resolve(process.env.PORTABLE_EXECUTABLE_DIR);
-    app.setPath('appData', portableExecutableDir);
-    app.setPath(
-      'userData',
-      join(portableExecutableDir, `${PRODUCT_NAME} - User Data`),
-    );
-    app.setPath(
-      'temp',
-      join(portableExecutableDir, `${PRODUCT_NAME} - Temporary Files`),
-    );
-  } else if (IS_TEST && PRODUCT_NAME) {
-    app.setPath('userData', join(app.getPath('appData'), PRODUCT_NAME));
   }
 
   initUpdater();
@@ -232,14 +423,8 @@ if (gotTheLock) {
       details.reason !== 'clean-exit';
 
     if (isGpuCrash || isFatalRendererCrash) {
-      // Send to telemetry
-      captureException(
-        new Error(`${type} process crashed: ${details.reason}`),
-        {
-          extra: { ...details },
-          tags: { reason: details.reason, type },
-        },
-      );
+      // Send to telemetry and save local diagnostics before Chromium can abort.
+      void captureGpuCrash(type, details);
 
       if (!isHwAccelDisabled()) {
         log(
@@ -289,6 +474,10 @@ if (gotTheLock) {
   // Listen for child process crashes, especially GPU
   app.on('child-process-gone', (_, details) => {
     handleProcessCrash(details.type, details);
+  });
+
+  app.on('gpu-info-update', () => {
+    writeGpuDiagnosticSnapshot(getGpuDiagnosticSnapshot('gpu-info-update'));
   });
 
   // Listen for renderer crashes
@@ -367,6 +556,10 @@ function getCrashCount() {
 
 function getCrashCountFilePath() {
   return join(app.getPath('userData'), 'crash-count.json');
+}
+
+function getGpuDiagnosticsFilePath() {
+  return join(app.getPath('userData'), 'gpu-diagnostics.json');
 }
 
 function getHwAccelFilePath() {


### PR DESCRIPTION
### Motivation

- Improve observability and local debugging for Chromium/Electron GPU failures that trigger the fatal "GPU process isn't usable" path. 
- Preserve useful GPU state and environment information before Chromium aborts so Sentry events and local investigations have actionable context.

### Description

- Enrich Sentry `beforeSend` so minidump events that include the Chromium `LOG_FATAL` message "GPU process isn't usable" gain a `gpuDiagnostic` context and a `gpuFatal=unusable-gpu-process` tag.  
- Add `captureGpuCrash` which collects a GPU diagnostic snapshot (GPU feature status, app/runtime info, environment/display/session variables, Chromium switches, screen info) and `basic` GPU info, sends that to Sentry, and persists a rolling history to `<userData>/gpu-diagnostics.json`.  
- Add optional Chromium GPU diagnostics controlled by environment variables `M3_ENABLE_GPU_DIAGNOSTICS`, `M3_DISABLE_GPU_SANDBOX`, and `M3_IN_PROCESS_GPU` to enable logging and test sandbox/in-process GPU modes, and add a `gpu-info-update` listener to snapshot state when Chromium updates GPU info.  
- Add small Linux fallback: when the app is already disabling hardware acceleration due to crash-loop handling, also append the Chromium `disable-gpu-sandbox` switch to improve fallback reliability, and add helpers for app data path configuration used by diagnostics. 

### Testing

- Ran linting and autofix with `yarn lint` / `eslint --fix`, and applied fixes so no lint errors remain after changes.  
- Ran focused Electron unit tests with `yarn vitest --project electron src-electron/main/__tests__/architecture.test.ts src-electron/main/__tests__/utils.test.ts` and the tests passed (`2 files, 40 tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed3d7bc908331b4c4055eef2572e0)