### PR TITLE
Improve isUsablePath handling for network and Windows extended paths and add telemetry

### DIFF
--- a/src-electron/main/__tests__/fs.test.ts
+++ b/src-electron/main/__tests__/fs.test.ts
@@ -228,7 +228,77 @@ describe('isUsablePath', () => {
     await expect(isUsablePath(String.raw`\\192.168.4.38\Test`)).resolves.toBe(
       false,
     );
+    expect(addElectronBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'filesystem',
+        data: expect.objectContaining({
+          code: 'UNKNOWN',
+          likelyNetworkPath: true,
+          resolvedBase: String.raw`\\192.168.4.38\Test`,
+          testDir: String.raw`\\192.168.4.38\Test/.cache-test-test-uuid`,
+        }),
+        level: 'warning',
+        message: '[isUsablePath] Probe failed',
+      }),
+    );
     expect(captureElectronErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('treats ENOENT on likely network paths as unusable without reporting', async () => {
+    setPlatform('win32');
+    const error = new Error(
+      String.raw`ENOENT: no such file or directory, mkdir '\?'`,
+    );
+    (error as Error & { code?: string }).code = 'ENOENT';
+    mkdirMock.mockRejectedValue(error);
+
+    const { isUsablePath } = await import('../fs');
+
+    await expect(isUsablePath('G:/My Drive/Meeting Media')).resolves.toBe(
+      false,
+    );
+
+    expect(addElectronBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'filesystem',
+        data: expect.objectContaining({
+          basePath: 'G:/My Drive/Meeting Media',
+          code: 'ENOENT',
+          likelyNetworkPath: true,
+          resolvedBase: 'G:/My Drive/Meeting Media',
+          testDir: 'G:/My Drive/Meeting Media/.cache-test-test-uuid',
+        }),
+        level: 'warning',
+      }),
+    );
+    expect(captureElectronErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt a probe when a Windows path resolves to the extended-path marker', async () => {
+    setPlatform('win32');
+
+    const { isUsablePath } = await import('../fs');
+
+    await expect(isUsablePath(String.raw`\?`)).resolves.toBe(false);
+
+    expect(mkdirMock).not.toHaveBeenCalled();
+    expect(addElectronBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'filesystem',
+        data: expect.objectContaining({
+          basePath: String.raw`\?`,
+          resolvedBase: String.raw`\?`,
+          testDir: String.raw`\?/.cache-test-test-uuid`,
+        }),
+        level: 'error',
+      }),
+    );
+    expect(captureElectronErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Invalid Windows path resolved for filesystem probe',
+      }),
+      expect.anything(),
+    );
   });
 
   it('notifies renderer on probe errors when one configured folder is likely network-based', async () => {

--- a/src-electron/main/fs.ts
+++ b/src-electron/main/fs.ts
@@ -239,6 +239,22 @@ export async function getAppDataPath(): Promise<string> {
 
 const isUsablePathPromises = new Map<string, Promise<boolean>>();
 
+const NETWORK_PATH_TRANSIENT_ERRORS = new Set(['ENOENT', 'UNKNOWN']);
+
+const getProbePathContext = (basePath: string) => {
+  const resolvedBase = resolve(basePath);
+  const testDir = join(resolvedBase, '.cache-test-' + uuid());
+  const testFile = join(testDir, 'test.txt');
+  return { resolvedBase, testDir, testFile };
+};
+
+const isInvalidWindowsResolvedPath = (resolvedBase: string) => {
+  if (process.platform !== 'win32') return false;
+
+  const unixResolvedBase = toUnix(resolvedBase);
+  return unixResolvedBase === '/?' || unixResolvedBase === '//?';
+};
+
 const WINDOWS_RETRYABLE_PROBE_CODES = new Set(['EBUSY', 'EPERM']);
 
 const getErrorCode = (error: unknown) => (error as { code?: string })?.code;
@@ -349,13 +365,16 @@ export function isUsablePath(basePath?: string): Promise<boolean> {
 
   if (!isUsablePathPromises.has(basePath)) {
     const promise = (async () => {
+      const { resolvedBase, testDir, testFile } = getProbePathContext(basePath);
+      const likelyNetworkPath = isPossiblyNetworkFolderPath(basePath);
+
       try {
-        const resolvedBase = resolve(basePath);
-        const testDir = join(resolvedBase, '.cache-test-' + uuid());
+        if (isInvalidWindowsResolvedPath(resolvedBase)) {
+          throw new Error('Invalid Windows path resolved for filesystem probe');
+        }
 
         await mkdir(testDir, { recursive: true });
 
-        const testFile = join(testDir, 'test.txt');
         await writeFile(testFile, 'ok');
         await delay(PATH_PROBE_SETTLE_DELAY_MS);
 
@@ -364,22 +383,32 @@ export function isUsablePath(basePath?: string): Promise<boolean> {
         return true;
       } catch (e) {
         const PERMISSION_ERRORS = new Set(['EACCES', 'EPERM']);
-        const NETWORK_PATH_TRANSIENT_ERRORS = new Set(['UNKNOWN']);
-        const code = (e as { code?: string }).code;
+        const code = getErrorCode(e);
+        const transientNetworkError =
+          NETWORK_PATH_TRANSIENT_ERRORS.has(code ?? '') && likelyNetworkPath;
         if (hasPossibleNetworkPathInNotificationSettings()) {
           notifyPathProbeNetworkWarning();
         }
-        if (
-          !PERMISSION_ERRORS.has(code ?? '') &&
-          !(
-            NETWORK_PATH_TRANSIENT_ERRORS.has(code ?? '') &&
-            isPossiblyNetworkFolderPath(basePath)
-          )
-        ) {
+        addElectronBreadcrumb({
+          category: 'filesystem',
+          data: {
+            basePath,
+            code,
+            configuredPathCount: pathProbeNotificationPaths.size,
+            hasConfiguredNetworkPath:
+              hasPossibleNetworkPathInNotificationSettings(),
+            likelyNetworkPath,
+            resolvedBase,
+            testDir,
+          },
+          level: transientNetworkError ? 'warning' : 'error',
+          message: '[isUsablePath] Probe failed',
+        });
+        if (!PERMISSION_ERRORS.has(code ?? '') && !transientNetworkError) {
           captureElectronError(e, {
             contexts: {
               fn: {
-                args: { basePath },
+                args: { basePath, likelyNetworkPath, resolvedBase, testDir },
                 name: 'isUsablePath',
               },
             },


### PR DESCRIPTION
### Motivation

- Reduce noisy error reporting for transient failures when probing likely network-mounted folders.
- Properly handle Windows extended-path marker `\?` to avoid invalid probe attempts.
- Provide richer breadcrumb/telemetry context for filesystem probe failures to aid diagnosis.
- Ensure renderer notifications are triggered when a configured path is likely network-based.

### Description

- Add `NETWORK_PATH_TRANSIENT_ERRORS` and treat `ENOENT`/`UNKNOWN` as transient for likely network paths.  
- Introduce `getProbePathContext` to centralize `resolvedBase`, `testDir`, and `testFile` computation and use `uuid()` for probe dirs.  
- Add `isInvalidWindowsResolvedPath` to detect resolved Windows extended-path markers and short-circuit probes with an error.  
- Change `isUsablePath` to compute probe context once, mark `likelyNetworkPath`, record a breadcrumb with `basePath`, `code`, `likelyNetworkPath`, `resolvedBase`, and `testDir`, and only call `captureElectronError` when the error is not a permission or transient network error.  
- Update probe notification logic to still call `sendToWindow` when a configured path appears network-based.  
- Add and update unit tests in `src-electron/main/__tests__/fs.test.ts` to cover ENOENT/UNKNOWN handling, extended-path `\?` behavior, and breadcrumb/notification expectations.

### Testing

- Ran unit tests in `src-electron/main/__tests__/fs.test.ts` via the project's test runner to validate the new probe behavior and telemetry assertions.  
- The updated and new tests covering transient network errors, `ENOENT` handling, `\?` path behavior, and notification behavior all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed75501688331b49f3ec1c0e014a7)