### PR TITLE
fix: avoid blocking media file checks

### DIFF
--- a/src/components/media/MediaItem.vue
+++ b/src/components/media/MediaItem.vue
@@ -1256,7 +1256,7 @@ const mediaTitle = ref(props.media.title);
 
 const { basename, fileUrlToPath, fs } = globalThis.electronApi;
 
-const { pathExists, pathExistsSync, statSync } = fs;
+const { pathExists, stat } = fs;
 const PATH_ACCESS_WARNING_THROTTLE_MS = 30000;
 
 let lastPathAccessWarningAt = 0;
@@ -1385,12 +1385,12 @@ const notifyPathAccessWarning = () => {
   });
 };
 
-const fileIsLocal = () => {
+const fileIsLocal = async () => {
   const filePath = fileUrlToPath(props.media.fileUrl);
   try {
-    const fileExists = pathExistsSync(filePath);
+    const fileExists = await pathExists(filePath);
     const remoteSizeKnown = props.media.filesize !== undefined;
-    const localSize = fileExists ? statSync(filePath).size : 0;
+    const localSize = fileExists ? (await stat(filePath)).size : 0;
 
     if (!fileExists) return false;
     if (!remoteSizeKnown) return true;
@@ -1413,11 +1413,18 @@ const fileIsLocal = () => {
   }
 };
 
-const localFile = ref(fileIsLocal());
+const localFile = ref(false);
+let localFileCheckId = 0;
 
-const { pause } = useTimeoutPoll(() => {
-  localFile.value = fileIsLocal();
-}, 1000);
+const updateLocalFile = async () => {
+  const checkId = ++localFileCheckId;
+  const isLocal = await fileIsLocal();
+  if (checkId === localFileCheckId) {
+    localFile.value = isLocal;
+  }
+};
+
+const { pause } = useTimeoutPoll(updateLocalFile, 1000);
 
 const markersPanelOpen = ref(false);
 const startSelectedMarker = ref<null | VideoMarker>(null);
@@ -1455,7 +1462,7 @@ const setMediaPlaying = async (
     }
   }
   skipCustomDurationUpdateOnce.value = false;
-  localFile.value = fileIsLocal();
+  await updateLocalFile();
 
   mediaPlaying.value = {
     action:
@@ -1745,7 +1752,7 @@ function stopMedia(forOtherMediaItem = false) {
     zoom: 1,
   };
   mediaToStop.value = '';
-  localFile.value = fileIsLocal();
+  void updateLocalFile();
   playbackRate.value = 1;
   postPlaybackRate(1);
 
@@ -1937,6 +1944,7 @@ const confirmDeleteSelectedMedia = () => {
 };
 
 onMounted(async () => {
+  void updateLocalFile();
   initializeImageDuration();
   if (props.media.duration && !props.media.thumbnailUrl)
     await findThumbnailUrl();


### PR DESCRIPTION
### Motivation
- Users reported occasional 2–5s UI freezes on app startup/profile load that felt like synchronous work blocking the renderer thread. 
- Investigation found `MediaItem.vue` performing synchronous filesystem probes (`pathExistsSync`/`statSync`) during component setup which can block rendering when many items or slow/network paths are present.

### Description
- Replaced synchronous filesystem checks in `src/components/media/MediaItem.vue` with async calls (`pathExists`, `stat`) and made `fileIsLocal` async to avoid blocking the renderer. 
- Added an async refresh helper `updateLocalFile()` with a simple request-id guard to prevent stale async results from overwriting newer state. 
- Updated call sites to use the async refresh (startup `onMounted`, `setMediaPlaying`, `stopMedia`) so the UI can render immediately while file checks run in the background. 
- Commit: `ac7bb4e` (`fix: avoid blocking media file checks`).

### Testing
- Ran lint on the changed file with `yarn eslint -c ./eslint.config.js './src/components/media/MediaItem.vue'` which completed successfully. 
- Ran type checks with `yarn vue-tsc --noEmit -p tsconfig.json` which completed successfully. 
- Ran unit tests with `yarn test:unit --run` and the test suite completed with all tests passing (`39` test files, `279` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2183b71528833186899bfde5026fce)