### PR TITLE
[codex] stabilize media drag sorting

### DIFF
--- a/src/components/media/MediaList.vue
+++ b/src/components/media/MediaList.vue
@@ -52,7 +52,11 @@
           :some-items-are-hidden="someItemsAreHidden"
         />
       </template>
-      <template v-for="element in sortableItems" :key="element.uniqueId">
+      <div
+        v-for="element in sortableItems"
+        :key="element.uniqueId"
+        class="sortable-media__item"
+      >
         <!-- Render dividers -->
         <MediaDivider
           v-if="element.type === 'divider'"
@@ -115,7 +119,7 @@
             })
           "
         />
-      </template>
+      </div>
     </div>
 
     <!-- Add Divider Dialog -->
@@ -199,7 +203,6 @@ import { log } from 'src/shared/vanilla';
 const { addDivider, deleteDivider, updateDividerColors, updateDividerTitle } =
   useMediaDividers(props.mediaList.config?.uniqueId);
 
-// Use the drag and drop composable - pass the reactive sectionData items directly
 const { dragDropContainer, isDragging, sortableItems } = useMediaDragAndDrop(
   sectionData.value?.items || [],
 );
@@ -334,22 +337,18 @@ defineExpose({
   sectionHeaderRef,
 });
 
-// Efficient watcher to ensure changes are persisted to the store
-// Only triggers when the actual array content changes, not on every re-render
+// Keep FormKit's draft order local while dragging, then persist the final order.
 watch(
   () => [
     sortableItems.value?.map((item) => item.uniqueId).join('|'),
     isDragging.value,
   ],
   ([, isCurrentlyDragging]) => {
-    if (isCurrentlyDragging) return; // Avoid updating while dragging
+    if (isCurrentlyDragging) return;
     if (!sectionData.value || !sortableItems.value || !selectedDateObject.value)
       return;
 
-    // Update the section data to match the sorted order
     updateStoreMediaOrder(sortableItems.value);
-
-    // Save section order information for watched media items
     queueWatchedMediaPersistence();
   },
   { flush: 'post' },
@@ -376,6 +375,10 @@ watch(
 
 .sortable-media {
   transition: background-color 0.2s ease;
+}
+
+.sortable-media__item {
+  width: 100%;
 }
 
 [data-dragging='true'] {

--- a/src/composables/useMediaDragAndDrop.ts
+++ b/src/composables/useMediaDragAndDrop.ts
@@ -4,19 +4,31 @@ import { animations, state } from '@formkit/drag-and-drop';
 import { useDragAndDrop } from '@formkit/drag-and-drop/vue';
 import { ref } from 'vue';
 
-export function useMediaDragAndDrop(items: MediaItem[]) {
-  const isDragging = ref(false);
+const isDragging = ref(false);
+let dragStateListenersRegistered = false;
 
-  // Use the drag and drop composable with shared group for cross-section dragging
+export function useMediaDragAndDrop(items: MediaItem[]) {
+  registerDragStateListeners();
+
   const [dragDropContainer, reactiveItems] = useDragAndDrop<MediaItem>(items, {
-    group: 'mediaList', // Shared group to allow cross-section dragging
+    draggable: (child) => child.classList.contains('sortable-media__item'),
+    group: 'mediaList',
     multiDrag: true,
     plugins: [animations()],
-    // Don't use a selected class since we're handling selection independently with click events
+    // Don't use a selected class since we're handling selection independently with click events.
     selectedClass: undefined,
   });
 
-  // Handle drag state
+  return {
+    dragDropContainer,
+    isDragging,
+    sortableItems: reactiveItems,
+  };
+}
+
+function registerDragStateListeners() {
+  if (dragStateListenersRegistered) return;
+
   state.on('dragStarted', () => {
     isDragging.value = true;
   });
@@ -25,9 +37,5 @@ export function useMediaDragAndDrop(items: MediaItem[]) {
     isDragging.value = false;
   });
 
-  return {
-    dragDropContainer,
-    isDragging,
-    sortableItems: reactiveItems,
-  };
+  dragStateListenersRegistered = true;
 }

--- a/src/pages/MediaCalendarPage.vue
+++ b/src/pages/MediaCalendarPage.vue
@@ -109,13 +109,7 @@
     <template v-if="!showEmptyState">
       <template
         v-for="mediaList in mediaLists"
-        :key="
-          selectedDateObject?.date +
-          '-' +
-          mediaList.config?.uniqueId +
-          '-' +
-          mediaList.items?.length
-        "
+        :key="selectedDateObject?.date + '-' + mediaList.config?.uniqueId"
       >
         <MediaList
           :ref="(el) => (mediaListRefs[mediaList.sectionId] = el)"


### PR DESCRIPTION
## Summary

- Keep FormKit's existing draft-list behavior and deferred Pinia persistence after drag completion.
- Wrap each sortable media value in one stable draggable child so helper/empty-state rows are not part of FormKit's item/value mapping.
- Add a `draggable` predicate that only targets those sortable wrappers.
- Keep `MediaList` component keys stable across item-count changes so cross-section moves do not remount active drag containers.
- Register the shared FormKit drag-state listeners once instead of once per media list instance.

## Why

The original delayed persistence model was the right fit for FormKit: writing every intermediate drag order directly into Pinia caused heavy reactivity churn and sluggish drag feedback. This PR now preserves the original model while addressing the concrete instability risks found during testing.

The likely cross-list clone issue was `MediaList` being keyed by `mediaList.items?.length`; moving between lists changes item counts during drag, which can remount the active drag containers. The item wrapper and `draggable` predicate also ensure FormKit sees exactly one draggable child per sortable value, excluding the drop/empty-state row.

## Validation

- `yarn eslint -c ./eslint.config.js './src/**/*.{js,ts,cjs,mjs,mts,vue}'`
- `git diff --check`

`yarn vue-tsc --noEmit -p tsconfig.json` was attempted earlier but failed on existing Electron/robotjs typing issues unrelated to this change (`@jitsi/robotjs` module/type resolution and the electron API mock shape).