### PR TITLE
Skip macOS quit prompt during updater install and expose install-in-progress flag

### DIFF
--- a/src-electron/electron-main.ts
+++ b/src-electron/electron-main.ts
@@ -32,7 +32,10 @@ import {
   setAppQuitting,
   setShouldQuit,
 } from 'src-electron/main/session';
-import { initUpdater } from 'src-electron/main/updater';
+import {
+  initUpdater,
+  isUpdateInstallInProgress,
+} from 'src-electron/main/updater';
 import {
   captureElectronError,
   isIgnoredNativeCrashEvent,
@@ -517,7 +520,12 @@ if (gotTheLock) {
 
   app.on('before-quit', (e) => {
     setAppQuitting(true);
+
+    // Windows/Linux close prompts are handled by the BrowserWindow 'close'
+    // listener. This handler only adds the macOS app-quit prompt, and updater
+    // installs must bypass it so quitAndInstall can complete.
     if (PLATFORM !== 'darwin') return;
+    if (isUpdateInstallInProgress()) return;
     if (!mainWindowInfo.mainWindow || mainWindowInfo.mainWindow.isDestroyed())
       return;
     if (authorizedClose.authorized) {

--- a/src-electron/main/__tests__/updater.test.ts
+++ b/src-electron/main/__tests__/updater.test.ts
@@ -74,14 +74,18 @@ describe('updater install flow', () => {
   });
 
   it('calls quitAndInstall only once for duplicate install requests', async () => {
-    const { initUpdater, quitAndInstallUpdate } = await import('../updater');
+    const { initUpdater, isUpdateInstallInProgress, quitAndInstallUpdate } =
+      await import('../updater');
 
     await initUpdater();
     handlers.get('update-downloaded')?.({ version: '26.6.2' });
 
+    expect(isUpdateInstallInProgress()).toBe(false);
+
     quitAndInstallUpdate();
     quitAndInstallUpdate();
 
+    expect(isUpdateInstallInProgress()).toBe(true);
     expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
     expect(quitAndInstallMock).toHaveBeenCalledWith(false, true);
   });

--- a/src-electron/main/updater.ts
+++ b/src-electron/main/updater.ts
@@ -52,6 +52,8 @@ const updaterLogger = {
 let updateDownloaded = false;
 let updateInstallStarted = false;
 
+export const isUpdateInstallInProgress = () => updateInstallStarted;
+
 interface UpdateDownloadProgressInfo {
   bytesPerSecond?: number;
   delta?: number;


### PR DESCRIPTION
### Motivation
- Prevent the macOS app-quit confirmation prompt from blocking the updater's `quitAndInstall` flow by short-circuiting `before-quit` when an update install is in progress.

### Description
- Added export `isUpdateInstallInProgress` in `src-electron/main/updater.ts` to expose the `updateInstallStarted` state via `isUpdateInstallInProgress()`.
- Updated `app.on('before-quit')` in `src-electron/electron-main.ts` to bypass the macOS quit prompt when `isUpdateInstallInProgress()` returns `true`.
- Adjusted `src-electron/main/__tests__/updater.test.ts` to import and assert the `isUpdateInstallInProgress` state and to validate that duplicate install requests only call `quitAndInstall` once.

### Testing
- Ran the updater unit tests in `src-electron/main/__tests__/updater.test.ts` which verify install state transitions and duplicate install-request handling, and they passed.
- Ran the project's automated test suite (`vitest`) and all tests related to the updater changes succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46a45a7200833195c7689dc02de058)