### PR TITLE
fix: guard updater error detail matching

### DIFF
--- a/src-electron/main/__tests__/utils.test.ts
+++ b/src-electron/main/__tests__/utils.test.ts
@@ -173,6 +173,23 @@ describe('isUpdaterFullDownloadFallbackError', () => {
     ).toBe(false);
   });
 
+  it('should handle non-string error fields during updater full download fallback', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-04T12:00:00.000Z'));
+
+    markUpdaterFullDownloadFallback(
+      'Cannot download differentially, fallback to full download: Error: net::ERR_NETWORK_IO_SUSPENDED',
+    );
+
+    expect(
+      isUpdaterFullDownloadFallbackError({
+        code: 500,
+        message: 'net::ERR_NETWORK_IO_SUSPENDED',
+        name: { value: 'Error' },
+      }),
+    ).toBe(false);
+  });
+
   it('should stop ignoring partial download errors after the fallback window', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-04T12:00:00.000Z'));

--- a/src-electron/main/utils.ts
+++ b/src-electron/main/utils.ts
@@ -357,10 +357,14 @@ function getErrorDetails(error: unknown) {
   }
 
   return {
-    code: (error as { code?: string })?.code,
+    code: getErrorDetailText((error as { code?: unknown })?.code),
     message: error instanceof Error ? error.message : undefined,
-    name: (error as Error)?.name,
+    name: getErrorDetailText((error as { name?: unknown })?.name),
   };
+}
+
+function getErrorDetailText(value: unknown) {
+  return typeof value === 'string' ? value : undefined;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Updater error objects with non-string `code` or `name` fields caused `TypeError` when `includes` was called on those fields, as seen in runtime reports. 
- Make updater error matching resilient to malformed or non-string error fields so Sentry/ignore logic cannot throw.

### Description
- Add `getErrorDetailText(value: unknown)` helper that returns the value only when it's a string. 
- Use the helper in `getErrorDetails` to safely extract `code` and `name` as strings or `undefined` before any `includes` checks. 
- Add a regression test `should handle non-string error fields during updater full download fallback` in `src-electron/main/__tests__/utils.test.ts` that verifies non-string fields do not cause a crash.

### Testing
- Ran `yarn vitest run src-electron/main/__tests__/utils.test.ts --project electron` and the test file passed (`19` tests passed). 
- Ran `yarn lint` and lint checks passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46aad23c9c8331bafe32a05482ba7f)