### PR TITLE
Derive `TEST_VERSION` at runtime and remove secret; use strict env check in `quasar.config.ts`

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -137,7 +137,6 @@ jobs:
       MAC_CERTIFICATE_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      TEST_VERSION: 'false'
 
   rerun-on-failure:
     needs: [build]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,6 @@ on:
         required: true
       SONAR_TOKEN:
         required: true
-      TEST_VERSION:
-        required: true
 
 jobs:
   sonarqube:
@@ -151,7 +149,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GITHUB_TOKEN: ${{ github.token }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          TEST_VERSION: ${{ secrets.TEST_VERSION }}
+          TEST_VERSION: ${{ !inputs.publish-release }}
 
       - name: Retry build without notarization (macOS agreement expired)
         if: runner.os == 'macOS' && steps.build.outcome == 'failure'
@@ -161,7 +159,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          TEST_VERSION: ${{ secrets.TEST_VERSION }}
+          TEST_VERSION: ${{ !inputs.publish-release }}
       - name: Clean up keychain and provisioning profile
         if: always() && runner.os == 'macOS' && github.actor != 'dependabot[bot]'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,3 @@ jobs:
       MAC_CERTIFICATE_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
       SENTRY_AUTH_TOKEN: ''
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      TEST_VERSION: 'true'

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -151,7 +151,6 @@ jobs:
       MAC_CERTIFICATE_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      TEST_VERSION: 'false'
 
   # publish-release:
   #   name: 'Publish release'

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -13,7 +13,7 @@ import { name, productName, repository, version } from './package.json';
 // Environment
 const IS_DEV = process.env.NODE_ENV === 'development';
 const IS_BETA = version.includes('beta');
-const IS_TEST = process.env.TEST_VERSION == 'true';
+const IS_TEST = process.env.TEST_VERSION === 'true';
 
 // App
 const APP_NAME = `${name}${IS_TEST ? '-test' : ''}`;


### PR DESCRIPTION
### Motivation
- Avoid depending on a repository secret for test build toggling by computing the test flag from the job input instead of a `TEST_VERSION` secret.
- Prevent accidental publication of test builds by tying `TEST_VERSION` to the `publish-release` input at runtime.
- Ensure environment checks are robust by using a strict equality comparison for `process.env.TEST_VERSION`.

### Description
- Removed `TEST_VERSION` from workflow secrets and references in `.github/workflows/build.yml`, `.github/workflows/ci.yml`, `.github/workflows/beta-release.yml`, and `.github/workflows/manual-release.yml`.
- Set the build-time environment variable `TEST_VERSION` dynamically in `build.yml` to `
  ${{ !inputs.publish-release }}` so it resolves at workflow runtime instead of via a secret.
- Kept the existing behavior for publishing vs. test builds by using the `publish-release` input to determine `TEST_VERSION`.
- Changed `quasar.config.ts` to use strict comparison `process.env.TEST_VERSION === 'true'` when deriving `IS_TEST`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46ad3188108331b5a161d0e8bad177)