### PR TITLE
fix: make the downloaded FFmpeg executable on macOS and Linux

### DIFF
--- a/src-electron/electron-preload.ts
+++ b/src-electron/electron-preload.ts
@@ -148,6 +148,7 @@ const electronApi: ElectronApi = {
   sendKeyTap: (k, m) => sendKeyTap(k, m),
   setAutoStartAtLogin: (v) => send('toggleOpenAtLogin', v),
   setElectronUrlVariables: (v) => send('setElectronUrlVariables', v),
+  setExecutable: (p) => invoke('setExecutable', p),
   setHardwareAcceleration: (v) => invoke('set-hardware-acceleration', v),
   setPathProbeNotificationPaths: (paths) =>
     send('setPathProbeNotificationPaths', paths),

--- a/src-electron/main/fs.ts
+++ b/src-electron/main/fs.ts
@@ -10,6 +10,7 @@ import { app, dialog } from 'electron';
 import { ensureDir, type Stats } from 'fs-extra';
 import { createReadStream, createWriteStream } from 'node:fs';
 import {
+  chmod,
   copyFile,
   mkdir,
   open,
@@ -992,6 +993,33 @@ export async function saveFileDialog(
     defaultPath,
     filters,
   });
+}
+
+/**
+ * Gives a file the executable bit, on the platforms that have one.
+ *
+ * Unzipping does not carry permissions across — yauzl reports an entry's mode
+ * but nothing here applies it, so every extracted file lands as 0644. That is
+ * harmless for publication content, but the FFmpeg binary the app downloads for
+ * itself is extracted the same way and then cannot be spawned at all.
+ *
+ * Windows decides executability by extension and has no bit to set, so there is
+ * nothing to do there.
+ *
+ * @param path The file to make executable
+ * @returns Whether the file can be executed afterwards
+ */
+export async function setExecutable(path: string): Promise<boolean> {
+  if (process.platform === 'win32') return true;
+  try {
+    await chmod(path, 0o755);
+    return true;
+  } catch (error) {
+    captureElectronError(error, {
+      contexts: { fn: { name: 'setExecutable', path } },
+    });
+    return false;
+  }
 }
 
 /**

--- a/src-electron/main/ipc.ts
+++ b/src-electron/main/ipc.ts
@@ -47,6 +47,7 @@ import {
   openFileDialog,
   openFolderDialog,
   saveFileDialog,
+  setExecutable,
   setPathProbeNotificationPaths,
   startSecurityScopedAccess,
   unwatchFolders,
@@ -425,6 +426,10 @@ handleIpcInvoke(
   'createVideoFromNonVideo',
   async (_e, path: string, ffmpegPath: string, outputDir?: string) =>
     createVideoFromNonVideo(path, ffmpegPath, outputDir),
+);
+
+handleIpcInvoke('setExecutable', async (_e, path: string) =>
+  setExecutable(path),
 );
 
 handleIpcInvoke(

--- a/src/helpers/fs.ts
+++ b/src/helpers/fs.ts
@@ -71,6 +71,7 @@ const {
   pathToFileURL,
   readdir,
   resolve,
+  setExecutable,
   unwatchFolders,
   unzip,
   watchFolder,
@@ -420,18 +421,31 @@ export const setupFFmpeg = async (): Promise<string> => {
     const ffmpegDir = await getFFmpegDirectory();
     const ffmpegZipPath = join(ffmpegDir, version.name);
 
+    let ffmpegPath: string;
     if (await validateExistingFile(ffmpegZipPath, version.size, ffmpegDir)) {
-      return currentState.ffmpegPath;
+      ffmpegPath = currentState.ffmpegPath;
+    } else {
+      const resolvedFfmpegDir = await downloadFfmpeg(
+        version.browser_download_url,
+        ffmpegDir,
+      );
+      ffmpegPath = await unzipAndFindFFmpeg(
+        join(resolvedFfmpegDir, version.name),
+        resolvedFfmpegDir,
+      );
     }
 
-    const resolvedFfmpegDir = await downloadFfmpeg(
-      version.browser_download_url,
-      ffmpegDir,
-    );
-    const ffmpegPath = await unzipAndFindFFmpeg(
-      join(resolvedFfmpegDir, version.name),
-      resolvedFfmpegDir,
-    );
+    // Unzipping does not carry permissions across, so the binary arrives without
+    // its executable bit and cannot be spawned on macOS or Linux. Both branches
+    // above funnel through here, including the one that reuses an
+    // already-downloaded copy, so an install left broken by an earlier version
+    // repairs itself on the next run rather than needing a fresh download.
+    if (!(await setExecutable(ffmpegPath))) {
+      // Leaving the path in the store would have the early return above hand out
+      // an unusable binary for the rest of the session.
+      currentState.ffmpegPath = '';
+      return '';
+    }
 
     currentState.ffmpegPath = ffmpegPath;
     return ffmpegPath;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -266,6 +266,14 @@ export interface ElectronApi {
   sendKeyTap: (key: string, modifiers?: string[]) => void;
   setAutoStartAtLogin: (value: boolean) => void;
   setElectronUrlVariables: (variables: string) => void;
+  /**
+   * Gives a file the executable bit, on the platforms that have one.
+   *
+   * @param path - The file to make executable.
+   * @returns Whether the file can be executed afterwards. Always true on
+   *   Windows, which has no such bit.
+   */
+  setExecutable: (path: string) => Promise<boolean>;
   setHardwareAcceleration: (disabled: boolean) => void;
   setPathProbeNotificationPaths: (paths: string[]) => void;
   showFileOnWindows: (filePath: string) => Promise<void>;
@@ -383,6 +391,7 @@ export type ElectronIpcInvokeKey =
   | 'registerShortcut'
   | 'saveFileDialog'
   | 'set-hardware-acceleration'
+  | 'setExecutable'
   | 'startSecurityScopedAccess'
   | 'unwatchFolders'
   | 'unzip'

--- a/test/vitest/mocks/electronApi.ts
+++ b/test/vitest/mocks/electronApi.ts
@@ -227,6 +227,9 @@ export const electronApi: ElectronApi = {
   setElectronUrlVariables: function (variables) {
     throw new Error('Function not implemented.');
   },
+  setExecutable: function (path) {
+    throw new Error('Function not implemented.');
+  },
   setHardwareAcceleration: function (disabled) {
     throw new Error('Function not implemented.');
   },


### PR DESCRIPTION
## Proposed Changes

The FFmpeg binary the app downloads for itself is extracted without its executable bit on macOS and Linux, so it can never be spawned.

`unzipFile` reads each entry's mode from yauzl but never applies it, so every extracted file lands as `0644`. That is harmless for publication content, but `unzipAndFindFFmpeg` returns a path to a binary that cannot be run. Everything that shells out to FFmpeg then fails with `EACCES`:

- media export
- converting a still or an audio file into a video

Windows decides executability by extension and has no bit to set, which is likely why this has gone unnoticed.

Reproduced on macOS 15 (arm64). The downloaded binary is intact — it runs correctly as soon as the bit is set by hand:

```
$ ls -la <userData>/ffmpeg/ffmpeg
-rw-r--r--  80128296  ffmpeg

$ <userData>/ffmpeg/ffmpeg -version
permission denied

$ chmod +x <userData>/ffmpeg/ffmpeg && <userData>/ffmpeg/ffmpeg -version
ffmpeg version 6.1-tessus  https://evermeet.cx/ffmpeg/
```

### Changes

- `setExecutable()` in `src-electron/main/fs.ts` — `chmod 0o755`, a no-op on Windows — exposed over IPC and preload
- `setupFFmpeg()` calls it once it has a path

The two branches of `setupFFmpeg` were restructured so both reach that call. The one that matters is the branch reusing an already-downloaded copy: it means an install left broken by an earlier version repairs itself on the next launch, rather than needing the cache cleared first.

A failed `chmod` clears the cached path, since leaving it would have the early return at the top of `setupFFmpeg` hand out the unusable binary for the rest of the session.

### Alternative considered

Applying entry modes in `unzipFile` itself would be the more general fix, but it changes permissions for every archive the app extracts — `.jwpub` content among them — for the benefit of one file that is known to need it. This keeps the blast radius to FFmpeg.

### Verification

`yarn lint`, `yarn vue-tsc --noEmit` and `yarn test:unit` all pass on this branch. One pre-existing failure in `src/utils/__tests__/api.test.ts > fetchMemorials` reproduces on an unmodified `master` and is unrelated.