### PR TITLE
fix(scripts): make electron-rebuild script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/sircharlo/meeting-media-manager.git"
   },
   "scripts": {
-    "electron-rebuild": "./node_modules/.bin/electron-rebuild.cmd -f -m ./node_modules/@jitsi/robotjs",
+    "electron-rebuild": "electron-rebuild -f -m ./node_modules/@jitsi/robotjs",
     "generate:icons": "node ./build/svg2font.js",
     "generate:jw-icons-fallbacks": "node ./scripts/update-jw-icons-fallbacks.mjs",
     "generate:logos": "node ./build/generate-logos.js",


### PR DESCRIPTION
### Summary
This PR fixes the `electron-rebuild` yarn script by removing the `.cmd` extension and the explicit path to `./node_modules/.bin/`. 

### Context & Problem
Previously, the script referenced `./node_modules/.bin/electron-rebuild.cmd`, which only exists on Windows environments. This broke execution on Linux/macOS, where yarn generate binary symlinks without the `.cmd` extension.

### Solution
By invoking `electron-rebuild` directly, yarn will automatically resolve the correct executable from `node_modules/.bin` according to the host OS, making the script cross-platform.