### PR TITLE
fix(sentry): stop reporting transient yeartext network noise and duplicate preload causes

### DIFF
--- a/src-electron/preload/__tests__/log.test.ts
+++ b/src-electron/preload/__tests__/log.test.ts
@@ -1,0 +1,77 @@
+import { captureException } from '@sentry/electron/renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { capturePreloadError } from '../log';
+
+vi.mock('@sentry/electron/renderer', () => ({
+  captureException: vi.fn(),
+}));
+
+// The electron test setup mocks src-electron/preload/log (so tests of other
+// preload modules don't hit Sentry); restore the real implementation here so
+// capturePreloadError itself is what's under test.
+vi.mock('src-electron/preload/log', async (importOriginal) => {
+  const mod = await importOriginal<object>();
+  return { ...mod };
+});
+
+describe('capturePreloadError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports an error without a cause once', () => {
+    const error = new Error('outer only');
+
+    capturePreloadError(error);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(error, undefined);
+  });
+
+  it('reports only the cause when an error wraps another error', () => {
+    const cause = new Error('the actual failure');
+    const outer = new Error('wrapper', { cause });
+
+    capturePreloadError(outer);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(cause, undefined);
+  });
+
+  it('recurses through nested causes without reporting any wrapper', () => {
+    const root = new Error('root cause');
+    const middle = new Error('middle', { cause: root });
+    const outer = new Error('outer', { cause: middle });
+
+    capturePreloadError(outer);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(root, undefined);
+  });
+
+  it('passes the context through to the reported cause', () => {
+    const cause = new Error('the actual failure');
+    const outer = new Error('wrapper', { cause });
+    const context = { contexts: { fn: { name: 'somePreloadFn' } } };
+
+    capturePreloadError(outer, context);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(cause, context);
+  });
+
+  it('drops raw DOM events', () => {
+    capturePreloadError(new Event('error'));
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('drops an event used as a cause', () => {
+    const outer = new Error('wrapper', { cause: new Event('error') });
+
+    capturePreloadError(outer);
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/src-electron/preload/log.ts
+++ b/src-electron/preload/log.ts
@@ -9,8 +9,24 @@ type CaptureCtx = Parameters<typeof captureException>[1];
  * @param context The context to log with the error
  */
 export function capturePreloadError(error: unknown, context?: CaptureCtx) {
-  if (error instanceof Error && error.cause) {
-    capturePreloadError(error.cause, context);
+  // Raw DOM events (e.g. a <video>/<audio> 'error' event with no attached
+  // MediaError) carry no message or stack trace and are useless in Sentry.
+  if (typeof Event !== 'undefined' && error instanceof Event) return;
+
+  const cause =
+    (error instanceof Error && error.cause) ||
+    (typeof error === 'object' && error !== null && 'cause' in error
+      ? (error as { cause: unknown }).cause
+      : undefined);
+
+  // The cause is the actual failure; the outer error is just a wrapper
+  // adding context, so only the cause needs its own Sentry report.
+  if (
+    cause instanceof Error ||
+    (typeof Event !== 'undefined' && cause instanceof Event)
+  ) {
+    capturePreloadError(cause, context);
+    return;
   }
 
   if (import.meta.env.IS_DEV) {

--- a/src/stores/__tests__/jw.test.ts
+++ b/src/stores/__tests__/jw.test.ts
@@ -325,4 +325,30 @@ describe('JW Store', () => {
       ]);
     });
   });
+
+  describe('updateYeartextFontUrls', () => {
+    it('does not report transient network failures to Sentry', async () => {
+      const store = useJwStore();
+      const api = await import('src/utils/api');
+      vi.mocked(api.fetchRaw).mockRejectedValue(
+        new TypeError('Failed to fetch (wol.jw.org)'),
+      );
+
+      await store.updateYeartextFontUrls();
+
+      expect(errorCatcher).not.toHaveBeenCalled();
+    });
+
+    it('reports non-network failures to Sentry', async () => {
+      const store = useJwStore();
+      const api = await import('src/utils/api');
+      vi.mocked(api.fetchRaw).mockRejectedValue(
+        new Error('Unexpected parse failure'),
+      );
+
+      await store.updateYeartextFontUrls();
+
+      expect(errorCatcher).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/stores/jw.ts
+++ b/src/stores/jw.ts
@@ -24,6 +24,7 @@ import {
   findMediaSection,
   getOrCreateMediaSection,
 } from 'src/helpers/media-sections';
+import { isFetchNetworkError } from 'src/shared/network-errors';
 import {
   extractCssUrls,
   findIconUrlInCss,
@@ -689,6 +690,7 @@ export const useJwStore = defineStore('jw-store', {
               ...getYeartextFontUrlsFromCss(cssText),
             };
           } catch (e) {
+            if (isFetchNetworkError(e)) continue;
             errorCatcher(e, {
               contexts: {
                 fn: { args: { cssUrl }, name: 'updateYeartextFontUrls' },
@@ -697,6 +699,7 @@ export const useJwStore = defineStore('jw-store', {
           }
         }
       } catch (e) {
+        if (isFetchNetworkError(e)) return;
         errorCatcher(e, {
           contexts: { fn: { name: 'updateYeartextFontUrls - main' } },
         });


### PR DESCRIPTION
Two Sentry-error-noise fixes from a triage session (Sentry queue is now at 0 unresolved):

### 1. Yeartext font discovery: transient network failures no longer reported (`c455bdbf3`)
`updateYeartextFontUrls` reported every fetch failure to Sentry, unlike `fetchJson` which filters these through `isFetchNetworkError`. Transient `TypeError: Failed to fetch (wol.jw.org)` errors were being filed as bugs (Sentry issue MMM-V2-3H4). Both catch blocks now skip `errorCatcher` for classified network errors, with regression tests.

### 2. Preload error causes reported only once (`ae9c053b9`)
`capturePreloadError` recursed into `error.cause` but kept going, so the outer wrapper error was also captured — the same duplicate-cause reporting the renderer `errorCatcher` already fixed. It now returns after recursing and matches the renderer's cause extraction, including dropping raw DOM events. Regression tests cover nested causes, context pass-through, and event causes.

## Checks
- `yarn eslint` (changed files) — clean
- `yarn vue-tsc --noEmit -p tsconfig.json` — clean
- `yarn test:unit` — 518/518 passing (6 new tests)