### PR TITLE
fix(obs): prevent UUID scenes from being sent as sceneName to OBS

### DIFF
--- a/src/components/dialog/DialogObsPopup.vue
+++ b/src/components/dialog/DialogObsPopup.vue
@@ -200,6 +200,20 @@ const getSetSceneArguments = (newProgramScene: string) => {
   const hasSceneUuid = scenes.value?.every((scene) => 'sceneUuid' in scene);
   const useUuid = hasSceneUuid && configuredScenesAreAllUUIDs.value;
 
+  if (isUUID(newProgramScene) && !useUuid) {
+    log('OBS scene UUID would be sent as sceneName', 'obs', 'warn', {
+      configuredScenesAreAllUUIDs: configuredScenesAreAllUUIDs.value,
+      hasSceneUuid,
+      newProgramScene,
+      obsCameraScene: currentSettings.value?.obsCameraScene,
+      obsImageScene: currentSettings.value?.obsImageScene,
+      obsMediaScene: currentSettings.value?.obsMediaScene,
+      sampleScenes: scenes.value?.slice(0, 3),
+      scenesCount: scenes.value?.length,
+      useUuid,
+    });
+  }
+
   return {
     ...(useUuid
       ? { sceneUuid: newProgramScene }
@@ -227,10 +241,23 @@ const setObsScene = async (sceneType?: ObsSceneType, desiredScene?: string) => {
     if (!newProgramScene) return;
 
     if (sceneExists(newProgramScene)) {
-      await obsWebSocketInfo.obsWebSocket?.call(
-        'SetCurrentProgramScene',
-        getSetSceneArguments(newProgramScene),
-      );
+      const args = getSetSceneArguments(newProgramScene);
+
+      // A UUID value must always be sent as sceneUuid, never sceneName.
+      // If configuredScenesAreAllUUIDs was momentarily false (e.g. during
+      // store rehydration, congregation switch, or settings save),
+      // getSetSceneArguments could incorrectly return { sceneName: uuid }.
+      // Force the correct key when the value is unmistakably a UUID.
+      if (isUUID(newProgramScene) && 'sceneName' in args) {
+        await obsWebSocketInfo.obsWebSocket?.call('SetCurrentProgramScene', {
+          sceneUuid: newProgramScene,
+        });
+      } else {
+        await obsWebSocketInfo.obsWebSocket?.call(
+          'SetCurrentProgramScene',
+          args,
+        );
+      }
     } else {
       notifySceneNotFound();
     }

--- a/src/components/media/ObsStatus.vue
+++ b/src/components/media/ObsStatus.vue
@@ -192,7 +192,7 @@ const initObsListeners = async () => {
       fetchSceneList();
     });
     obsWebSocketInfo.obsWebSocket.on('SceneListChanged', (data) => {
-      scenes.value = data.scenes;
+      scenes.value = data.scenes.reverse();
     });
     obsConnect();
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes Sentry issue **MMM-V2-3HB** — OBS error "No source was found by the name of" when `configuredScenesAreAllUUIDs` briefly returns `false` during store rehydration, congregation switch, or settings save.

## Changes

### Defensive guard in `setObsScene` (`DialogObsPopup.vue`)
After `getSetSceneArguments` returns its result, `setObsScene` now checks: if the scene value is a UUID but the arguments object contains `sceneName` (instead of `sceneUuid`), it bypasses the incorrect args and directly sends `{ sceneUuid }`. This is strictly more correct — a UUID is never valid as a `sceneName` parameter — and prevents the error regardless of what transient state caused `configuredScenesAreAllUUIDs` to return `false`.

### Diagnostic logging in `getSetSceneArguments` (`DialogObsPopup.vue`)
When the function is about to send a UUID value as `{ sceneName: ... }`, it now logs a full diagnostic payload — the three configured scene values, the `configuredScenesAreAllUUIDs` state, and a sample of the `scenes` array. This will surface the exact conditions in production so the transient root cause can be identified and addressed.

### SceneListChanged consistency fix (`ObsStatus.vue`)
The `SceneListChanged` event handler was assigning `data.scenes` directly, but `fetchSceneList` applies `.reverse()` to the scene list. Fixed to match so both paths produce identically-ordered scene arrays.

## Testing
- `vue-tsc --noEmit` passes cleanly on both files
- No new dependencies introduced