### PR TITLE
ci(docs): verify docs:lint check name

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,33 @@
+name: Docs lint
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-ci.yml'
+
+concurrency:
+  group: docs-lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-lint:
+    name: docs:lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install
+      - name: Prepare Quasar
+        run: yarn quasar prepare
+      - name: Lint docs
+        run: yarn docs:lint

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,6 +10,11 @@ queue_rules:
       - -files ~= ^(?!.*\.(md|json)$)
     merge_conditions:
       - -draft
+      - or:
+          - check-success = "docs:lint"
+          - check-neutral = "docs:lint"
+          - check-skipped = "docs:lint"
+          - -files ~= ^docs/
     batch_size: 10
   - name: bots
     queue_conditions:


### PR DESCRIPTION
Temporary verification PR for the new PR-time docs lint workflow. Will be closed without merging after reading the reported check-run name.