### PR TITLE
ci(docs): run docs:lint on PRs touching docs/**

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,33 @@
+name: Docs lint
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-ci.yml'
+
+concurrency:
+  group: docs-lint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-lint:
+    name: docs:lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install
+      - name: Prepare Quasar
+        run: yarn quasar prepare
+      - name: Lint docs
+        run: yarn docs:lint

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,6 +10,11 @@ queue_rules:
       - -files ~= ^(?!.*\.(md|json)$)
     merge_conditions:
       - -draft
+      - or:
+          - check-success = "docs:lint"
+          - check-neutral = "docs:lint"
+          - check-skipped = "docs:lint"
+          - -files ~= ^docs/
     batch_size: 10
   - name: bots
     queue_conditions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For translations of the most important changes, see the [`./release-notes/`](./r
 
 ### 🔧 Chores
 
+- 🔧 **CI**: Pull requests that touch the docs site now run a `docs:lint` gate, so corrupted Crowdin translations are rejected before they can merge and break the docs deploy.
 - 🔧 **Dependencies**: Updated Quasar, Electron, Vue i18n, ESLint, Sentry, and several other dependencies.
 - 🔧 **Docs**: Fixed the renamed VitePress image option and deduplicated heading anchors to unblock the docs build.
 - 🔧 **Dev Tooling**: Added dev-only demo-mode tooling and made the Electron rebuild script cross-platform.


### PR DESCRIPTION
## What

Adds a PR-time `docs:lint` gate so corrupted Crowdin translations are rejected **before** they merge, instead of breaking the next docs deploy (which has been red on every run since Aug 30, when l10n PR #8945 shipped double spaces before French heading anchors).

### Changes

- **`.github/workflows/docs-ci.yml`** (new): runs `yarn docs:lint` on `pull_request` events touching `docs/**` (or the workflow file), mirroring the docs deploy's quality job (Node 24, `quasar prepare`, pinned action SHAs).
- **`.mergify.yml`**: the `translations` queue now requires the `docs:lint` check (confirmed live at that exact name on #9014) in its merge conditions, with a `-files ~= ^docs/` escape so i18n/release-notes-only translation PRs are unaffected. `docs:lint` must pass before such PRs merge.

## Notes

- The `docs:lint` check will show **red on this PR** — the merge base still contains the broken translated docs, which is precisely the failure this gate catches. A companion change repairing those files (`fix/docs-lint`: `fr/faq.md` heading anchors, `ko/about.md` duplicate anchor, `ko/index.md` link slugs) follows this PR; merging both turns the deploy green.
- The Mergify `bots` queue (dependabot) is intentionally untouched — those PRs never touch `docs/**`.