### PR TITLE
fix(docs): repair Crowdin-corrupted anchors and links in translations

### DIFF
--- a/docs/src/fr/faq.md
+++ b/docs/src/fr/faq.md
@@ -56,7 +56,7 @@ M³ inclut un assistant de configuration qui vous guide à travers la configurat
 
 ## Gestion des médias {#faq-media-management}
 
-### :desktop_computer: Comment M³ télécharge-t-il les médias ?  {#media-download}
+### :desktop_computer: Comment M³ télécharge-t-il les médias ? {#media-download}
 
 M³ télécharge automatiquement les médias pour les réunions à venir en :
 
@@ -66,7 +66,7 @@ M³ télécharge automatiquement les médias pour les réunions à venir en :
 4. Organisant les médias par date et type de réunion
 5. Mettant en cache les fichiers pour une utilisation hors ligne
 
-### :calendar: Puis-je télécharger des médias pour des dates spécifiques ?  {#specific-dates}
+### :calendar: Puis-je télécharger des médias pour des dates spécifiques ? {#specific-dates}
 
 Oui ! M³ vous permet de :
 
@@ -84,7 +84,7 @@ Vous pouvez importer des médias personnalisés de plusieurs façons :
 - **Fichiers multimédias pour les discours publics** : Importer des fichiers JWPUB au format S-34 ou S-34mp pour les discours publics
 - **Outils pour la Bible et la Bible d'étude** : Ajoutez des enregistrements audio de la Bible, des ressources multimédias depuis la Bible d'étude ou des ressources multimédias de la Bible en langue des signes
 
-### :speaker: Puis-je importer des enregistrements audio de la Bible ?  {#audio-bible}
+### :speaker: Puis-je importer des enregistrements audio de la Bible ? {#audio-bible}
 
 Oui ! M³ inclut une fonctionnalité Bible audio qui vous permet de :
 
@@ -95,7 +95,7 @@ Oui ! M³ inclut une fonctionnalité Bible audio qui vous permet de :
 
 ## Fonctionnalités de présentation des médias {#faq-presentation-features}
 
-### :tv: Comment présenter des médias pendant les réunions ?  {#present-media}
+### :tv: Comment présenter des médias pendant les réunions ? {#present-media}
 
 Pour présenter des médias :
 
@@ -105,7 +105,7 @@ Pour présenter des médias :
 4. Utiliser les fonctionnalités de zoom/pan pour les images
 5. Couper une vidéo si nécessaire
 
-### :keyboard: Quels raccourcis clavier sont disponibles ?  {#faq-keyboard-shortcuts}
+### :keyboard: Quels raccourcis clavier sont disponibles ? {#faq-keyboard-shortcuts}
 
 M³ prend en charge les raccourcis clavier personnalisables pour :
 
@@ -116,7 +116,7 @@ M³ prend en charge les raccourcis clavier personnalisables pour :
 
 <!-- - Fullscreen mode -->
 
-### :notes: Comment la musique de fond fonctionne-t-elle ?  {#faq-background-music}
+### :notes: Comment la musique de fond fonctionne-t-elle ? {#faq-background-music}
 
 Les fonctionnalités de musique de fond incluent :
 
@@ -132,7 +132,7 @@ Oui. Lorsqu'elle est activée, M³ peut afficher une fenêtre de chronométrage 
 
 Le minuteur est une fonctionnalité en version bêta et ne doit être activé qu'après avoir été approuvé localement.
 
-### :video_camera: Comment configurer l'intégration Zoom ?  {#zoom-setup}
+### :video_camera: Comment configurer l'intégration Zoom ? {#zoom-setup}
 
 Pour intégrer avec Zoom :
 
@@ -142,7 +142,7 @@ Pour intégrer avec Zoom :
 
 ## Intégration OBS Studio {#faq-obs-integration}
 
-### :video_camera: Comment configurer l'intégration OBS Studio ?  {#faq-obs-setup}
+### :video_camera: Comment configurer l'intégration OBS Studio ? {#faq-obs-setup}
 
 Pour intégrer avec OBS Studio :
 
@@ -152,7 +152,7 @@ Pour intégrer avec OBS Studio :
 4. Configurez les scènes pour la caméra, les médias et les images
 5. Testez la lecture
 
-### :arrows_counterclockwise: Comment fonctionne le basculement automatique des scènes ?  {#faq-scene-switching}
+### :arrows_counterclockwise: Comment fonctionne le basculement automatique des scènes ? {#faq-scene-switching}
 
 M³ bascule automatiquement les scènes OBS Studio en fonction de :
 
@@ -161,7 +161,7 @@ M³ bascule automatiquement les scènes OBS Studio en fonction de :
 - Paramètres comme "Différer les images"
 - Si vous revenez à la scène précédente après le média
 
-### :pause_button: Qu'est-ce que la fonction "Différer les images" ?  {#faq-postpone-images}
+### :pause_button: Qu'est-ce que la fonction "Différer les images" ? {#faq-postpone-images}
 
 Cette fonction retarde le partage des images vers OBS Studio jusqu'à ce que vous les déclenchez manuellement. C'est utile pour :
 
@@ -178,7 +178,7 @@ M³ n'inclut pas des fonctionnalités d'enregistrements intégrés, mais il peut
 
 ## Fonctionnalités avancées {#faq-advanced-features}
 
-### :cloud: Comment fonctionne la surveillance de dossiers ?  {#faq-folder-monitoring}
+### :cloud: Comment fonctionne la surveillance de dossiers ? {#faq-folder-monitoring}
 
 La surveillance de dossiers vous permet de :
 
@@ -194,7 +194,7 @@ L'exportation automatique des médias :
 3. Convertit les fichiers en format MP4 (optionnel)
 4. Maintenir une sauvegarde organisée des fichiers multimédias de la réunion
 
-### :family: Puis-je gérer plusieurs assemblées ?  {#faq-multiple-congregations}
+### :family: Puis-je gérer plusieurs assemblées ? {#faq-multiple-congregations}
 
 Oui ! M³ prend en charge plusieurs profils pour :
 
@@ -207,7 +207,7 @@ Les profils peuvent également être exportés vers un fichier JSON et importés
 
 ## Résolution des problèmes {#faq-troubleshooting}
 
-### :warning: Les médias ne téléchargent pas. Que dois-je vérifier ?  {#faq-media-not-downloading}
+### :warning: Les médias ne téléchargent pas. Que dois-je vérifier ? {#faq-media-not-downloading}
 
 Vérifiez ces problèmes courants :
 
@@ -218,7 +218,7 @@ Vérifiez ces problèmes courants :
 
 <!-- 5. **Manual Refresh**: Try manually refreshing to check for new media -->
 
-### :video_camera: L'intégration OBS Studio n'est pas fonctionnelle. Que dois-je vérifier ?  {#faq-obs-not-working}
+### :video_camera: L'intégration OBS Studio n'est pas fonctionnelle. Que dois-je vérifier ? {#faq-obs-not-working}
 
 Vérifiez ces problèmes liés à OBS Studio :
 
@@ -227,7 +227,7 @@ Vérifiez ces problèmes liés à OBS Studio :
 3. **Port et mot de passe** : Vérifiez les paramètres de votre port et de votre mot de passe OBS Studio
 4. **Pare-feu** : Assurez-vous que le pare-feu n'empêche pas la connexion
 
-### :speaker: M³ envoie-t-il automatiquement l'audio des médias à Zoom lors de l'utilisation d'OBS Studio ?  {#audio-to-zoom}
+### :speaker: M³ envoie-t-il automatiquement l'audio des médias à Zoom lors de l'utilisation d'OBS Studio ? {#audio-to-zoom}
 
 **Non.** M³ ne transmet pas automatiquement l'audio des médias à Zoom ou OBS Studio. Le flux vidéo fonctionne comme une caméra virtuelle sans son, tout comme une webcam. Pour avoir le son de la musique/vidéo disponible automatiquement dans Zoom, vous devez vous assurer que Zoom 'entend' le flux audio provenant de l'ordinateur, puis vous devez activer le paramètre **Audio Original** dans Zoom.
 
@@ -242,7 +242,7 @@ Vérifiez ces problèmes liés à OBS Studio :
 **Pourquoi est-ce nécessaire ?**
 M³ joue des médias avec son sur votre ordinateur, mais ce son n'est pas automatiquement transmis via le flux vidéo vers Zoom lors de l'utilisation d'OBS Studio. Le paramètre Audio Original permet à Zoom de capturer le son joué sur votre ordinateur lors du partage d'écran, si votre ordinateur est correctement configuré (par exemple : l'ordinateur a une deuxième carte son qui est utilisée pour la lecture des médias qui Zoom écoute comme un microphone.)
 
-### :snail: M³ fonctionne lentement. Comment puis-je améliorer les performances ?  {#performance-issues}
+### :snail: M³ fonctionne lentement. Comment puis-je améliorer les performances ? {#performance-issues}
 
 Essayez ces optimisations de performances :
 
@@ -262,7 +262,7 @@ Vérifiez ces paramètres de langue :
 
 ## Support et communauté {#support-community}
 
-### :radioactive: Comment signaler un problème ?  {#how-do-i-report-an-issue}
+### :radioactive: Comment signaler un problème ? {#how-do-i-report-an-issue}
 
 Veuillez [signaler le problème sur GitHub](https://github.com/sircharlo/meeting-media-manager/issues). Incluez :
 
@@ -271,7 +271,7 @@ Veuillez [signaler le problème sur GitHub](https://github.com/sircharlo/meeting
 - Votre système d'exploitation et la version de M³
 - Les messages d'erreur, les journaux et les captures d'écran
 
-### :new: Comment puis-je demander une nouvelle fonctionnalité ou une amélioration ?  {#how-can-i-request-a-new-feature-or-enhancement}
+### :new: Comment puis-je demander une nouvelle fonctionnalité ou une amélioration ? {#how-can-i-request-a-new-feature-or-enhancement}
 
 Veuillez [ouvrir une discussion](https://github.com/sircharlo/meeting-media-manager/discussions) sur GitHub. Décrivez :
 
@@ -279,11 +279,11 @@ Veuillez [ouvrir une discussion](https://github.com/sircharlo/meeting-media-mana
 - Comment elle bénéficierait aux utilisateurs
 - Toute exigence ou préférence spécifique
 
-### :handshake: Comment puis-je contribuer au code ?  {#how-can-i-contribute-some-code}
+### :handshake: Comment puis-je contribuer au code ? {#how-can-i-contribute-some-code}
 
 Veuillez [consulter le guide de contribution](https://github.com/sircharlo/meeting-media-manager/blob/master/CONTRIBUTING.md) sur GitHub. Nous accueillons les contributions de code et les Pull Requests !
 
-### :globe_with_meridians: Comment puis-je aider à la traduction ?  {#translations}
+### :globe_with_meridians: Comment puis-je aider à la traduction ? {#translations}
 
 M³ utilise Crowdin pour la gestion des traductions. Vous pouvez contribuer aux traductions en :
 
@@ -292,7 +292,7 @@ M³ utilise Crowdin pour la gestion des traductions. Vous pouvez contribuer aux 
 3. Traduction des phrases non traduites
 4. Examinant les traductions existantes
 
-### :x: Puis-je faire un don pour soutenir le projet ?  {#can-i-make-a-donation-to-the-project}
+### :x: Puis-je faire un don pour soutenir le projet ? {#can-i-make-a-donation-to-the-project}
 
 Merci de votre intérêt à soutenir le projet ! Cependant, dans l'esprit de Matthieu 10:8, les dons ne sont **pas** acceptés et ne le seront jamais. Cette appli a été faite avec amour et un peu de temps libre. Nous espérons que vous l'apprécierez ! :tada:
 

--- a/docs/src/ko/about.md
+++ b/docs/src/ko/about.md
@@ -14,7 +14,7 @@ This app used to be known as JWMMF (JW Meeting Media Fetcher), but was renamed t
 
 :::
 
-## M³를 사용하는 이유 {#why-choose-m3} {#why-choose-m3}
+## M³를 사용하는 이유 {#why-choose-m3}
 
 M³ is the ultimate tool for managing meeting media, offering a seamless, reliable, and feature-rich experience across platforms. It's designed specifically for the needs of congregation meetings and provides everything needed for effective media presentation.
 

--- a/docs/src/ko/index.md
+++ b/docs/src/ko/index.md
@@ -9,19 +9,19 @@ hero:
   actions:
     - theme: brand
       text: Download
-      link: /download
+      link: /ko/download
     - theme: brand
       text: About
-      link: /about
+      link: /ko/about
     - theme: brand
       text: User Guide
-      link: /user-guide
+      link: /ko/user-guide
     - theme: brand
       text: Settings Guide
-      link: /settings-guide
+      link: /ko/settings-guide
     - theme: brand
       text: FAQ
-      link: /faq
+      link: /ko/faq
 features:
   - icon: 🚀
     title: Automatic Media Management


### PR DESCRIPTION
## What

Repairs the translated docs corrupted by recent Crowdin l10n PRs, which have kept the docs deploy's `docs:lint` gate red on every run since Aug 30:

- **`docs/src/fr/faq.md`** — 21 headings with a double space before `{#anchor}` (introduced by l10n PR #8945)
- **`docs/src/ko/about.md`** — duplicated `{#why-choose-m3}` anchor (introduced by l10n PR #9007)
- **`docs/src/ko/index.md`** — 5 hero links stripped of the `/ko` prefix (introduced by l10n PR #9007)

Applied with the project's own fixer (`node docs/utils/fix-doc-markdown.mjs`, i.e. `yarn fix:docs`). No translation content changed — only heading whitespace, a duplicate anchor, and link slugs.

## Verification (the deploy's exact quality + build steps)

- `yarn docs:lint` → 0 links, 0 anchors, exit 0
- `yarn docs:test` → 7/7 tests pass
- `yarn docs:build` → VitePress build complete

## Notes

- The `docs:lint` PR-time check (new gate, #9015) only runs once that PR is merged onto master; it should be green on this PR's rerun. Until then, no docs check appears here.
- Merging both PRs makes the next docs deploy run green end-to-end.