### PR TITLE
fix(crowdin): stop blocking CI on unfixable link corruption, repair anchors faster

### DIFF
--- a/.github/workflows/crowdin-autorepair.yml
+++ b/.github/workflows/crowdin-autorepair.yml
@@ -6,17 +6,28 @@ name: Crowdin auto-repair
 # release-notes version headers, i18n link/param targets) and purges the
 # corrupted translation-memory segments, so the Crowdin GitHub App's PRs
 # come out clean. Docs link: frontmatter is not exposed by Crowdin as
-# translatable strings, so the sweep only logs a diagnostic for it and
-# docs/utils/fix-doc-markdown.mjs rewrites links locally.
+# translatable strings, so the sweep only logs a diagnostic for it -
+# docs:lint no longer fails a PR over it (VitePress recomputes the correct
+# locale-prefixed link at build time regardless of what's stored there), and
+# docs/utils/fix-doc-markdown.mjs remains available to tidy it up locally.
 #
 # A Crowdin webhook was considered for near-instant repair, but Crowdin's
 # custom webhook payload only accepts its own event variables as keys, so it
 # cannot emit the event_type that GitHub's repository_dispatch API requires
-# (API error "Events [client_payload, event_type] don't exist"). The hourly
-# schedule is the zero-infrastructure equivalent; the local --check guards in
-# dev/build/test still catch any broken output the moment it lands.
+# (API error "Events [client_payload, event_type] don't exist"). The push
+# trigger below is the next best thing: every time Crowdin's GitHub App
+# exports translations to l10n_master, this sweep runs within seconds and
+# patches any corruption in Crowdin's stored translations before it can be
+# leveraged into other strings. It can't force Crowdin to re-export an
+# already-open PR though (no API for that), so an in-flight PR can still
+# occasionally need a one-off local fix (docs/utils/fix-doc-markdown.mjs,
+# scripts/fix-i18n-locales.mjs) - the hourly schedule below is kept as a
+# project-wide backstop for corruption introduced between pushes.
 
 on:
+  push:
+    branches:
+      - l10n_master
   schedule:
     # Hourly; repairs anything saved since the last run. The cleanup is
     # idempotent, so overlapping/quick runs are harmless.
@@ -59,9 +70,10 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
         run: |
-          # Scheduled runs always apply a full sweep. Manual runs respect the
-          # language/apply inputs.
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          # Scheduled and push-triggered runs always apply a full sweep (push
+          # events carry no workflow_dispatch inputs to read). Manual runs
+          # respect the language/apply inputs.
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "push" ]; then
             node scripts/cleanup-crowdin.mjs --apply
             exit $?
           fi

--- a/docs/utils/fix-doc-markdown.mjs
+++ b/docs/utils/fix-doc-markdown.mjs
@@ -360,7 +360,6 @@ async function main() {
       }
     }
 
-    const changeCount = totals.linkChanges + totals.anchorChanges;
     console.log(
       `Done. ${checkOnly ? 'Found' : 'Fixed'} ${totals.linkChanges} link${totals.linkChanges === 1 ? '' : 's'} and ${totals.anchorChanges} anchor${totals.anchorChanges === 1 ? '' : 's'}.`,
     );
@@ -371,7 +370,15 @@ async function main() {
       );
     }
 
-    if (checkOnly && changeCount > 0) {
+    // link: frontmatter isn't exposed by Crowdin as a translatable string
+    // (URL-like values are excluded from translation - confirmed against the
+    // live project), so it can never come back from Crowdin correctly
+    // prefixed, and there's nothing "wrong" for a human to fix. It's also
+    // harmless: config.mts's transformPageData hook re-derives every hero
+    // action link from its slug at build time regardless of what's stored
+    // here. So --check only fails the build on anchor drift, which is a
+    // real, human-fixable-in-Crowdin defect.
+    if (checkOnly && totals.anchorChanges > 0) {
       process.exit(1);
     }
   } catch (error) {

--- a/scripts/cleanup-crowdin.mjs
+++ b/scripts/cleanup-crowdin.mjs
@@ -16,7 +16,10 @@
  *      sweeps confirmed Crowdin's markdown parser never exposes these as
  *      translatable strings (URL-like front matter is excluded), so there
  *      is nothing to repair via the API - the sweep logs that and leaves
- *      links to docs/utils/fix-doc-markdown.mjs.
+ *      links to docs/utils/fix-doc-markdown.mjs. docs:lint no longer fails
+ *      on this class: config.mts's transformPageData hook recomputes every
+ *      hero action link from its slug at build time, so a stale prefix here
+ *      never reaches production regardless of what Crowdin exports.
  *   4. Release-notes version headers (`## v26.7.0` in release-notes/en.md).
  *      These must stay byte-identical to the source, but translators keep
  *      localizing them - French scrambles (`## 7.0 v26.0`), Spanish drops


### PR DESCRIPTION
## Summary
- `docs:lint` was failing PR #9182 (and past ones like #9049) on Crowdin's `l10n_master` branch because a locale's `index.md` re-exported with an unprefixed `link:` value (e.g. `/download` instead of `/bzs/download`). That value is structurally excluded from Crowdin's translatable strings (URL-like front matter is auto-excluded from translation, confirmed against the live project), so there is no way to make Crowdin export it correctly — and it's already harmless, since [`config.mts`'s `transformPageData` hook](docs/.vitepress/config.mts#L202-L216) recomputes every hero action link from its slug at build time regardless of what's stored in frontmatter. `docs:lint`'s `--check` now only fails the build on real heading-anchor drift, the one class of docs corruption a human/translator can actually fix.
- Added a `push` trigger (`branches: l10n_master`) to `crowdin-autorepair.yml` alongside the existing hourly cron, so anchor and other Crowdin-side corruption gets patched via the API within seconds of an export landing, rather than waiting up to an hour. The scheduled sweep stays as a project-wide backstop (it also purges corrupted translation-memory segments, unrelated to any specific push).

## Context
PR #9182 was blocked by this exact `link:` corruption in `docs/src/bzs/index.md` plus a heading-anchor whitespace drift in `docs/src/uk/faq.md`; both were fixed directly on `l10n_master` in a separate commit. This PR is the durable fix so the `link:` class stops blocking future PRs entirely, and the anchor class gets caught closer to when it's introduced.

## Test plan
- [x] `node scripts/cleanup-crowdin.mjs --selftest` — 42/42 pass
- [x] `yarn docs:lint` — passes on `master`
- [x] Manually reproduced: corrupting a `link:` value locally now exits 0 under `--check` (previously exited 1); anchor drift still exits 1
- [x] Validated the modified workflow YAML parses correctly and the `push`/`schedule` branches both hit the `--apply` code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)