### PR TITLE
feat(i18n): add translation-quality review pipeline, pilot on French UI strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules
 # Freebuff thread-local metadata and scratch files
 /.freebuff/
 
+# Per-run output of scripts/i18n-quality (proposed edits, reports) - the
+# committed glossaries under scripts/i18n-quality/glossaries/ are NOT here
+/reports/translation-quality/
+
 # Quasar core related directories
 .quasar
 /dist

--- a/scripts/i18n-quality/README.md
+++ b/scripts/i18n-quality/README.md
@@ -1,0 +1,59 @@
+# Translation-quality review pipeline
+
+Reviews existing Crowdin translations for **naturalness** and **JW-appropriate
+terminology** against the English source — a different concern from
+`scripts/cleanup-crowdin.mjs` / `scripts/fix-i18n-locales.mjs`, which only
+repair mechanical corruption (broken syntax, mangled placeholders). Nothing
+here is auto-applied: every stage produces a file for the next stage or for
+human review, and only an explicit, human-approved `--apply` run of
+`apply-translation-quality-fixes.mjs` ever writes to Crowdin.
+
+Per `AGENTS.md`'s Crowdin rules, this pipeline never hand-edits a translated
+file — proposed fixes only ever reach Crowdin's stored translations through
+its API.
+
+## Pipeline
+
+1. **`extract-review-corpus.mjs`** (deterministic) — diffs a language's
+   translated files against English, skips untranslated strings and known
+   Crowdin-corruption patterns (owned by `cleanup-crowdin.mjs`), and emits a
+   corpus of candidates with their `@:`/`{param}` tokens flagged as
+   protected.
+2. **Grounding agent** (`prompts/grounding-agent.md`, one per language) —
+   researches `jw-terms-seed.json`'s terms on official jw.org pages in that
+   language and writes a committed, reusable glossary to `glossaries/<lang>.json`.
+3. **Review agent** (`prompts/review-short-strings.md`, batched ~150 records
+   per invocation) — proposes targeted edits with a category (phrasing /
+   terminology) and an admin-readable reason, citing the glossary for
+   terminology fixes.
+4. **`validate-proposed-changes.mjs`** (deterministic) — a guardrail gate:
+   rejects anything that mangles a protected token, is stale against the
+   live repo file, is a no-op, is missing a reason/category, or fails
+   vue-i18n compilation. Nothing is silently dropped — everything lands in
+   `validated/` or `rejected-by-guardrail/`.
+5. **`generate-report.mjs`** (deterministic) — renders `validated/` into a
+   Markdown report per (language, content type) — the actual thing a human
+   reads to decide what to approve.
+6. **`apply-translation-quality-fixes.mjs`** — takes a copy of a validated
+   report with `"status": "approved"` added to the entries a human wants
+   applied, resolves them to Crowdin string/translation IDs, and PATCHes
+   them via the API. Dry-run by default (mirrors `cleanup-crowdin.mjs`'s
+   `--apply` convention); always re-checks the live Crowdin text immediately
+   before writing and skips anything that's changed since review (a
+   translator or the hourly `crowdin-autorepair.yml` sweep may have touched
+   it) rather than clobbering it.
+
+## Output locations
+
+- `scripts/i18n-quality/glossaries/<lang>.json` — committed, reusable
+  per-language terminology references.
+- `reports/translation-quality/<run-id>/` — gitignored, per-run corpus/
+  proposed/validated/rejected output and the human-readable reports.
+
+## Status
+
+Pilot scope only: French, `src/i18n/en.json` + `docs/locales/en.json`
+("short UI strings"). Long-form prose (`docs/src/**`, `release-notes/*.md`),
+the other 13 shipped languages, and the 14 release-notes-only orphan
+languages are explicitly deferred — see the plan this was built from for
+the staged rollout and go/no-go checkpoints.

--- a/scripts/i18n-quality/apply-translation-quality-fixes.mjs
+++ b/scripts/i18n-quality/apply-translation-quality-fixes.mjs
@@ -164,6 +164,21 @@ async function main() {
     `[apply] project target languages: ${[...targetLanguageIds].join(', ')}`,
   );
 
+  // Our repo's LanguageValue codes (src/i18n/<code>.json) don't always match
+  // Crowdin's own language id (e.g. our "pt" is Crowdin's "pt-BR", "es" is
+  // "es-ES") - resolve via each target language's own twoLettersCode rather
+  // than assuming the codes are identical.
+  const languageIdByTwoLetters = new Map(
+    (project.targetLanguages ?? []).map((lang) => [
+      lang.twoLettersCode,
+      lang.id,
+    ]),
+  );
+  function resolveLanguageId(code) {
+    if (targetLanguageIds.has(code)) return code;
+    return languageIdByTwoLetters.get(code) ?? null;
+  }
+
   const files = await listAll(baseUrl, token, `/projects/${projectId}/files`);
   const normalizedFiles = files.map((file) => ({
     ...file,
@@ -213,22 +228,25 @@ async function main() {
 
     const byLanguage = new Map();
     for (const decision of decisions) {
-      if (!targetLanguageIds.has(decision.language)) {
-        console.warn(
-          `[apply] language "${decision.language}" is not in this project's targetLanguageIds - ` +
-            `check whether Crowdin uses a different code for it (e.g. es-ES, zh-CN, pt-BR) before re-running.`,
-        );
+      const resolvedLanguageId = resolveLanguageId(decision.language);
+      if (!resolvedLanguageId) {
+        unresolved.push({
+          decision,
+          reason: `language "${decision.language}" does not match any target language id or twoLettersCode in this Crowdin project`,
+          status: 'unresolved',
+        });
+        continue;
       }
-      const list = byLanguage.get(decision.language) ?? [];
+      const list = byLanguage.get(resolvedLanguageId) ?? [];
       list.push(decision);
-      byLanguage.set(decision.language, list);
+      byLanguage.set(resolvedLanguageId, list);
     }
 
-    for (const [language, languageDecisions] of byLanguage) {
+    for (const [crowdinLanguageId, languageDecisions] of byLanguage) {
       const translations = await listAll(
         baseUrl,
         token,
-        `/projects/${projectId}/languages/${encodeURIComponent(language)}/translations?fileId=${file.id}`,
+        `/projects/${projectId}/languages/${encodeURIComponent(crowdinLanguageId)}/translations?fileId=${file.id}`,
       );
       const translationsByStringId = new Map(
         translations.map((t) => [t.stringId, t]),

--- a/scripts/i18n-quality/apply-translation-quality-fixes.mjs
+++ b/scripts/i18n-quality/apply-translation-quality-fixes.mjs
@@ -385,8 +385,13 @@ async function resolveDecision(
     decision,
     matchedBy,
     status: 'resolved',
-    translationId: translation.id,
+    translationId: translation.translationId,
   };
 }
 
-await main();
+try {
+  await main();
+} catch (error) {
+  console.error(`[apply] ${error.message}`);
+  process.exitCode = 1;
+}

--- a/scripts/i18n-quality/apply-translation-quality-fixes.mjs
+++ b/scripts/i18n-quality/apply-translation-quality-fixes.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+/**
+ * Phase B of the translation-quality pipeline: apply user-approved
+ * proposed changes to Crowdin via its API. Dry-run by default, mirroring
+ * scripts/cleanup-crowdin.mjs's conventions (same crowdinRequest/listAll/
+ * patchTranslations shape, --apply to commit, non-zero exit when there is
+ * pending work).
+ *
+ * This never reads a raw validated/*.json file directly - it takes a
+ * *decisions* file: a copy of a validated/<lang>/<contentType>.json where
+ * the entries the admin actually wants applied have `"status": "approved"`
+ * added (everything else is left alone / status left as "validated" and
+ * skipped).
+ *
+ * Two open items this script does NOT resolve on its own, because they need
+ * one live API call against the real project to confirm rather than being
+ * guessed at (see the plan this was built from):
+ *   1. Whether Crowdin's JSON-source strings expose an `identifier` field
+ *      equal to the JSON key. If yes, that's the reliable match. If not,
+ *      this falls back to exact-text matching, which is only trusted when
+ *      the match is unique - src/i18n/en.json has 5 confirmed duplicate
+ *      values ("General", "Not playing", "Public talk", "Stop media",
+ *      "Verses"), so a non-unique text match is always reported unresolved,
+ *      never guessed.
+ *   2. Posting the reviewed `reason` as a Crowdin string comment - not
+ *      implemented (per explicit decision to keep review private for now;
+ *      the feature exists in Crowdin but its exact REST schema was not
+ *      confirmed live).
+ *
+ * Every run - dry or applied - prints the resolved language-id mapping and
+ * resolved/unresolved/stale counts before doing anything else. A stale
+ * decision (the live Crowdin translation no longer matches what was
+ * recorded at review time - e.g. a translator or the hourly
+ * crowdin-autorepair.yml job touched it since) is always skipped and
+ * reported, never overwritten.
+ *
+ * Usage:
+ *   node scripts/i18n-quality/apply-translation-quality-fixes.mjs <decisions-file> [<decisions-file> ...] [--apply]
+ *
+ * Environment: CROWDIN_PERSONAL_TOKEN, CROWDIN_PROJECT_ID (as
+ * scripts/cleanup-crowdin.mjs).
+ */
+import fsx from 'fs-extra';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const { pathExists, readJson } = fsx;
+
+const API_VERSION = '/api/v2';
+const PAGE_SIZE = 500;
+
+// Same source-file -> Crowdin-source-path mapping as crowdin.yml, needed to
+// resolve a contentType back to the Crowdin file that owns its strings.
+const SOURCE_PATH_BY_CONTENT_TYPE = {
+  'docs-locale': 'docs/locales/en.json',
+  i18n: 'src/i18n/en.json',
+};
+
+async function crowdinRequest(
+  baseUrl,
+  token,
+  path,
+  { body, method = 'GET' } = {},
+) {
+  const response = await fetch(`${baseUrl}${API_VERSION}${path}`, {
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    method,
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    const error = new Error(
+      `Crowdin API ${method} ${path} -> ${response.status} ${response.statusText}${detail ? `: ${detail.slice(0, 400)}` : ''}`,
+    );
+    error.body = detail;
+    throw error;
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+function getConfig() {
+  const token = process.env.CROWDIN_PERSONAL_TOKEN;
+  if (!token) {
+    throw new Error(
+      'Missing CROWDIN_PERSONAL_TOKEN env var (create one at https://crowdin.com/settings#api).',
+    );
+  }
+  const projectId =
+    process.env.CROWDIN_PROJECT_ID ?? parseProjectIdFromCrowdinYml();
+  if (!projectId) {
+    throw new Error(
+      'Missing CROWDIN_PROJECT_ID env var and no project_id found in crowdin.yml.',
+    );
+  }
+  return {
+    baseUrl: process.env.CROWDIN_BASE_URL ?? 'https://api.crowdin.com',
+    projectId,
+    token,
+  };
+}
+
+async function listAll(baseUrl, token, path) {
+  const items = [];
+  let offset = 0;
+  for (;;) {
+    const separator = path.includes('?') ? '&' : '?';
+    const page = await crowdinRequest(
+      baseUrl,
+      token,
+      `${path}${separator}limit=${PAGE_SIZE}&offset=${offset}`,
+    );
+    const rows = page.data ?? [];
+    for (const row of rows) items.push(row.data);
+    if (rows.length < PAGE_SIZE) break;
+    offset += PAGE_SIZE;
+  }
+  return items;
+}
+
+async function main() {
+  const { apply, decisionFiles } = parseArgs(process.argv.slice(2));
+  if (decisionFiles.length === 0) {
+    console.error(
+      'Usage: node apply-translation-quality-fixes.mjs <decisions-file> [...] [--apply]',
+    );
+    process.exit(1);
+  }
+
+  const { baseUrl, projectId, token } = getConfig();
+
+  const allDecisions = [];
+  for (const filePath of decisionFiles) {
+    if (!(await pathExists(filePath))) {
+      console.error(`Decisions file not found: ${filePath}`);
+      process.exit(1);
+    }
+    const records = await readJson(filePath);
+    for (const record of records) {
+      if (record.status === 'approved') allDecisions.push(record);
+    }
+  }
+
+  if (allDecisions.length === 0) {
+    console.log(
+      'No decisions marked "approved" in the given file(s). Nothing to do.',
+    );
+    return;
+  }
+
+  console.log(
+    `[apply] ${allDecisions.length} approved decision(s) across ${decisionFiles.length} file(s)`,
+  );
+
+  const project = (
+    await crowdinRequest(baseUrl, token, `/projects/${projectId}`)
+  ).data;
+  const targetLanguageIds = new Set(project.targetLanguageIds ?? []);
+  console.log(
+    `[apply] project target languages: ${[...targetLanguageIds].join(', ')}`,
+  );
+
+  const files = await listAll(baseUrl, token, `/projects/${projectId}/files`);
+  const normalizedFiles = files.map((file) => ({
+    ...file,
+    normalizedPath: normalizePath(file.path ?? file.name ?? ''),
+  }));
+
+  const byContentType = new Map();
+  for (const decision of allDecisions) {
+    const list = byContentType.get(decision.contentType) ?? [];
+    list.push(decision);
+    byContentType.set(decision.contentType, list);
+  }
+
+  const resolved = [];
+  const unresolved = [];
+  const stale = [];
+
+  for (const [contentType, decisions] of byContentType) {
+    const sourcePath = SOURCE_PATH_BY_CONTENT_TYPE[contentType];
+    if (!sourcePath) {
+      console.warn(
+        `[apply] unknown content type "${contentType}", skipping ${decisions.length} decision(s)`,
+      );
+      continue;
+    }
+    const file = normalizedFiles.find((f) =>
+      f.normalizedPath.endsWith(sourcePath),
+    );
+    if (!file) {
+      console.warn(
+        `[apply] could not find Crowdin file for ${sourcePath}, skipping ${decisions.length} decision(s)`,
+      );
+      continue;
+    }
+
+    const fileStrings = await listAll(
+      baseUrl,
+      token,
+      `/projects/${projectId}/strings?fileId=${file.id}`,
+    );
+    if (fileStrings[0] && fileStrings[0].identifier === undefined) {
+      console.warn(
+        `[apply] NOTE: strings for ${sourcePath} do not expose an "identifier" field - ` +
+          'falling back to exact-text matching for all decisions in this content type.',
+      );
+    }
+
+    const byLanguage = new Map();
+    for (const decision of decisions) {
+      if (!targetLanguageIds.has(decision.language)) {
+        console.warn(
+          `[apply] language "${decision.language}" is not in this project's targetLanguageIds - ` +
+            `check whether Crowdin uses a different code for it (e.g. es-ES, zh-CN, pt-BR) before re-running.`,
+        );
+      }
+      const list = byLanguage.get(decision.language) ?? [];
+      list.push(decision);
+      byLanguage.set(decision.language, list);
+    }
+
+    for (const [language, languageDecisions] of byLanguage) {
+      const translations = await listAll(
+        baseUrl,
+        token,
+        `/projects/${projectId}/languages/${encodeURIComponent(language)}/translations?fileId=${file.id}`,
+      );
+      const translationsByStringId = new Map(
+        translations.map((t) => [t.stringId, t]),
+      );
+
+      for (const decision of languageDecisions) {
+        const result = await resolveDecision(
+          { baseUrl, projectId, token },
+          decision,
+          fileStrings,
+          translationsByStringId,
+        );
+        if (result.status === 'resolved') resolved.push(result);
+        else if (result.status === 'stale') stale.push(result);
+        else unresolved.push(result);
+      }
+    }
+  }
+
+  console.log(
+    `\n[apply] resolved: ${resolved.length}, unresolved: ${unresolved.length}, stale: ${stale.length}`,
+  );
+
+  for (const { decision, reason } of unresolved) {
+    console.log(
+      `  UNRESOLVED  ${decision.language}/${decision.contentType}/${decision.key}: ${reason}`,
+    );
+  }
+  for (const { decision, liveText, reason } of stale) {
+    console.log(
+      `  STALE       ${decision.language}/${decision.contentType}/${decision.key}: ${reason}`,
+    );
+    console.log(
+      `              recorded: ${JSON.stringify(decision.currentTranslation)}`,
+    );
+    console.log(`              live now: ${JSON.stringify(liveText)}`);
+  }
+
+  console.log(`\n${apply ? 'Applying' : 'Dry run (pass --apply to commit)'}:`);
+  for (const { decision, matchedBy, translationId } of resolved) {
+    console.log(
+      `  [${matchedBy}] ${decision.language}/${decision.contentType}/${decision.key} (translationId ${translationId})`,
+    );
+    console.log(`    - ${JSON.stringify(decision.currentTranslation)}`);
+    console.log(`    + ${JSON.stringify(decision.proposedTranslation)}`);
+  }
+
+  if (apply && resolved.length > 0) {
+    const ops = resolved.map(({ decision, translationId }) => ({
+      op: 'replace',
+      path: `/${translationId}`,
+      value: { text: decision.proposedTranslation },
+    }));
+    await crowdinRequest(
+      baseUrl,
+      token,
+      `/projects/${projectId}/translations`,
+      {
+        body: ops,
+        method: 'PATCH',
+      },
+    );
+    console.log(`\n[apply] committed ${ops.length} translation(s) to Crowdin.`);
+  }
+
+  if (!apply && resolved.length > 0) {
+    process.exit(1);
+  }
+}
+
+function normalizePath(filePath) {
+  return filePath.replaceAll('\\', '/').replace(/^\/+/, '');
+}
+
+function parseArgs(argv) {
+  const args = { apply: false, decisionFiles: [] };
+  for (const arg of argv) {
+    if (arg === '--apply') args.apply = true;
+    else args.decisionFiles.push(arg);
+  }
+  return args;
+}
+
+function parseProjectIdFromCrowdinYml() {
+  try {
+    const content = readFileSync(
+      resolve(process.cwd(), 'crowdin.yml'),
+      'utf-8',
+    );
+    const match = /^project_id:\s*['"]?(\d+)['"]?\s*$/m.exec(content);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve each decision's Crowdin string+translation. Tries the `identifier`
+ * field first (if the live project exposes one matching the JSON key);
+ * falls back to a unique exact-text match. Never guesses on ambiguity.
+ */
+async function resolveDecision(
+  ctx,
+  decision,
+  fileStrings,
+  translationsByStringId,
+) {
+  const byIdentifier = fileStrings.find((s) => s.identifier === decision.key);
+  let stringMatch = byIdentifier;
+  let matchedBy = 'identifier';
+
+  if (!stringMatch) {
+    const textMatches = fileStrings.filter((s) => s.text === decision.sourceEn);
+    if (textMatches.length === 1) {
+      stringMatch = textMatches[0];
+      matchedBy = 'unique-text';
+    } else if (textMatches.length > 1) {
+      return {
+        decision,
+        reason: `ambiguous: ${textMatches.length} source strings share this exact text`,
+        status: 'unresolved',
+      };
+    }
+  }
+
+  if (!stringMatch) {
+    return {
+      decision,
+      reason: 'no matching source string found',
+      status: 'unresolved',
+    };
+  }
+
+  const translation = translationsByStringId.get(stringMatch.id);
+  if (!translation) {
+    return {
+      decision,
+      reason: 'no existing translation found for this string/language',
+      status: 'unresolved',
+    };
+  }
+
+  if (translation.text !== decision.currentTranslation) {
+    return {
+      decision,
+      liveText: translation.text,
+      reason:
+        'live Crowdin translation no longer matches the text this decision was reviewed against',
+      status: 'stale',
+    };
+  }
+
+  return {
+    decision,
+    matchedBy,
+    status: 'resolved',
+    translationId: translation.id,
+  };
+}
+
+await main();

--- a/scripts/i18n-quality/apply-translation-quality-fixes.mjs
+++ b/scripts/i18n-quality/apply-translation-quality-fixes.mjs
@@ -174,8 +174,17 @@ async function main() {
       lang.id,
     ]),
   );
+  // A few repo codes don't match Crowdin's id even by twoLettersCode -
+  // confirmed live against the project rather than guessed.
+  const LANGUAGE_ID_OVERRIDES = { 'cmn-hans': 'zh-CN' };
   function resolveLanguageId(code) {
     if (targetLanguageIds.has(code)) return code;
+    if (
+      LANGUAGE_ID_OVERRIDES[code] &&
+      targetLanguageIds.has(LANGUAGE_ID_OVERRIDES[code])
+    ) {
+      return LANGUAGE_ID_OVERRIDES[code];
+    }
     return languageIdByTwoLetters.get(code) ?? null;
   }
 

--- a/scripts/i18n-quality/extract-review-corpus.mjs
+++ b/scripts/i18n-quality/extract-review-corpus.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Extract the corpus of translated (non-identical-to-English) short UI
+ * strings a translation-quality review agent should look at, for one
+ * language.
+ *
+ * Deterministic and LLM-free: this is Phase 0 of the translation-quality
+ * pipeline (see the plan this was built from). It only diffs local files
+ * already checked out in the repo - it never talks to the Crowdin API.
+ *
+ * Covers `src/i18n/<lang>.json` and `docs/locales/<lang>.json` (both flat
+ * JSON, same "short UI string" shape). Long-form prose (docs/src/**,
+ * release-notes) is a separate, not-yet-built extractor - the shapes are
+ * different enough (headings, paragraphs, no stable key) to need their own
+ * chunking logic.
+ *
+ * A string is skipped (not emitted) when:
+ *  - the translation is identical to the English source (untranslated -
+ *    nothing to review; confirmed reliable across all enabled languages,
+ *    see the plan's scale research: zero missing-key edge cases anywhere).
+ *  - the source or translation matches a pattern already owned by
+ *    scripts/cleanup-crowdin.mjs's corruption-repair pipeline (version
+ *    headers, typographic-quote/whitespace-mangled `@:` links, doubled
+ *    anchors, scrambled version numbers) - a quality review must not
+ *    re-flag mechanical corruption that pipeline already fixes.
+ *
+ * Every emitted record carries `protectedTokens` (the `@:key` / `@:{'key'}`
+ * link targets and `{param}` names present in the English source) so a
+ * review agent - and later, validate-proposed-changes.mjs - can verify a
+ * proposed rewrite kept them byte-identical.
+ *
+ * Usage:
+ *   node scripts/i18n-quality/extract-review-corpus.mjs --language fr [--run-id <id>]
+ */
+import fsx from 'fs-extra';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const { ensureDir, readFile, writeFile } = fsx;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '../..');
+
+// ── Corruption-repair patterns, kept byte-identical to
+//    scripts/cleanup-crowdin.mjs so this extractor never re-flags what that
+//    pipeline already owns. ────────────────────────────────────────────────
+
+const TYPOGRAPHIC_QUOTES = '‚‘’‛“”„‟';
+const VERSION_HEADER_PATTERN = /^##(?!#)\s+v?\d+\.\d+\.\d+/;
+const LINK_TARGET_RE = /@:\{?'?([^'}\s]+)'?\}?/g;
+const PARAM_NAME_RE = /\{([\w]+)\}/g;
+const CORRUPTION_SIGNATURES = [
+  new RegExp(`@:\\{[^{}]*[${TYPOGRAPHIC_QUOTES}][^{}]*\\}`),
+  /@:[ \t]+(?=[\p{L}\p{N}_-])/u,
+  /\{#[\w-]+\}\s*\{#/,
+  /^(?:##\s*)?\d+\.\d+\s+v\d+\.\d+\s*$/,
+  /^(?:##\s*)?v\d+[ ,]\d+[,.]?\d*\s*$/,
+  /@:[^\s]*-(?=[\s.,;:!?]|$)/,
+];
+
+const CONTENT_SOURCES = [
+  {
+    contentType: 'i18n',
+    sourcePath: 'src/i18n/en.json',
+    translatedPathTemplate: 'src/i18n/{lang}.json',
+  },
+  {
+    contentType: 'docs-locale',
+    sourcePath: 'docs/locales/en.json',
+    translatedPathTemplate: 'docs/locales/{lang}.json',
+  },
+];
+
+async function extractForSource(
+  { contentType, sourcePath, translatedPathTemplate },
+  language,
+) {
+  const translatedPath = translatedPathTemplate.replace('{lang}', language);
+  const source = await readJson(sourcePath);
+  const translated = await readJson(translatedPath);
+
+  const records = [];
+  let skippedIdentical = 0;
+  let skippedCorrupted = 0;
+
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (typeof sourceValue !== 'string') continue;
+    const translatedValue = translated[key];
+    if (typeof translatedValue !== 'string') continue; // missing key - out of scope
+
+    if (translatedValue === sourceValue) {
+      skippedIdentical += 1;
+      continue;
+    }
+    if (
+      VERSION_HEADER_PATTERN.test(sourceValue) ||
+      isCorrupted(sourceValue) ||
+      isCorrupted(translatedValue)
+    ) {
+      skippedCorrupted += 1;
+      continue;
+    }
+
+    records.push({
+      contentType,
+      currentTranslation: translatedValue,
+      filePath: translatedPath,
+      key,
+      protectedTokens: extractProtectedTokens(sourceValue),
+      sourceEn: sourceValue,
+    });
+  }
+
+  return {
+    records,
+    skippedCorrupted,
+    skippedIdentical,
+    totalSourceKeys: Object.keys(source).length,
+  };
+}
+
+function extractProtectedTokens(sourceText) {
+  const links = [...sourceText.matchAll(LINK_TARGET_RE)].map((m) => m[1]);
+  const params = [...sourceText.matchAll(PARAM_NAME_RE)].map((m) => m[1]);
+  return { links, params };
+}
+
+function isCorrupted(text) {
+  return CORRUPTION_SIGNATURES.some((pattern) => pattern.test(text));
+}
+
+async function main() {
+  const { language, runId } = parseArgs(process.argv.slice(2));
+  if (!language) {
+    console.error(
+      'Usage: node extract-review-corpus.mjs --language <code> [--run-id <id>]',
+    );
+    process.exit(1);
+  }
+
+  const resolvedRunId = runId ?? new Date().toISOString().replace(/[:.]/g, '-');
+  const outDir = resolve(
+    REPO_ROOT,
+    'reports/translation-quality',
+    resolvedRunId,
+    'corpus',
+    language,
+  );
+  await ensureDir(outDir);
+
+  const summary = { language, runId: resolvedRunId, sources: [] };
+
+  for (const source of CONTENT_SOURCES) {
+    const { records, skippedCorrupted, skippedIdentical, totalSourceKeys } =
+      await extractForSource(source, language);
+
+    const outPath = resolve(outDir, `${source.contentType}.json`);
+    await writeFile(outPath, `${JSON.stringify(records, null, 2)}\n`, 'utf-8');
+
+    summary.sources.push({
+      contentType: source.contentType,
+      emitted: records.length,
+      outPath: outPath
+        .replace(`${REPO_ROOT}\\`, '')
+        .replace(`${REPO_ROOT}/`, ''),
+      skippedCorrupted,
+      skippedIdentical,
+      totalSourceKeys,
+    });
+
+    console.log(
+      `[${source.contentType}] ${language}: ${totalSourceKeys} source keys, ` +
+        `${skippedIdentical} untranslated (skipped), ${skippedCorrupted} known-corruption (skipped), ` +
+        `${records.length} emitted for review -> ${outPath}`,
+    );
+  }
+
+  console.log(`\nrun-id: ${resolvedRunId}`);
+  return summary;
+}
+
+function parseArgs(argv) {
+  const args = { language: null, runId: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--language') {
+      args.language = argv[i + 1];
+      i += 1;
+    } else if (argv[i] === '--run-id') {
+      args.runId = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+async function readJson(relativePath) {
+  const path = resolve(REPO_ROOT, relativePath);
+  return JSON.parse(await readFile(path, 'utf-8'));
+}
+
+await main();

--- a/scripts/i18n-quality/extract-review-corpus.mjs
+++ b/scripts/i18n-quality/extract-review-corpus.mjs
@@ -48,7 +48,15 @@ const REPO_ROOT = resolve(__dirname, '../..');
 
 const TYPOGRAPHIC_QUOTES = '‚‘’‛“”„‟';
 const VERSION_HEADER_PATTERN = /^##(?!#)\s+v?\d+\.\d+\.\d+/;
-const LINK_TARGET_RE = /@:\{?'?([^'}\s]+)'?\}?/g;
+// Excludes trailing sentence punctuation (,.;:!?)) from the captured
+// identifier, unlike cleanup-crowdin.mjs's same-purpose regex: that script
+// must mirror vue-i18n's actual (punctuation-inclusive) @:key grammar to
+// detect genuinely dangling runtime links, but this pipeline only needs the
+// referenced identifier itself, and a bare link immediately followed by
+// punctuation with no space (rare in English "@:key ", common in e.g.
+// Russian "@:key,") would otherwise extract a different token shape per
+// language purely from incidental trailing characters.
+const LINK_TARGET_RE = /@:\{?'?([^'}\s,.;:!?)]+)'?\}?/g;
 const PARAM_NAME_RE = /\{([\w]+)\}/g;
 const CORRUPTION_SIGNATURES = [
   new RegExp(`@:\\{[^{}]*[${TYPOGRAPHIC_QUOTES}][^{}]*\\}`),

--- a/scripts/i18n-quality/generate-report.mjs
+++ b/scripts/i18n-quality/generate-report.mjs
@@ -65,7 +65,7 @@ async function main() {
     ];
 
     records.forEach((record, index) => {
-      lines.push(renderRecord(record, index));
+      lines.push(renderRecord(record, index, language));
     });
 
     if (records.length === 0) {
@@ -92,7 +92,7 @@ function parseArgs(argv) {
   return args;
 }
 
-function renderRecord(record, index) {
+function renderRecord(record, index, language) {
   const lines = [
     `### ${index + 1}. \`${record.key}\` (${record.category}, confidence: ${record.confidence ?? 'unspecified'})`,
     '',
@@ -101,8 +101,8 @@ function renderRecord(record, index) {
     '| | Text |',
     '| --- | --- |',
     `| English source | ${escapeCell(record.sourceEn)} |`,
-    `| Current French | ${escapeCell(record.currentTranslation)} |`,
-    `| Proposed French | ${escapeCell(record.proposedTranslation)} |`,
+    `| Current ${language} | ${escapeCell(record.currentTranslation)} |`,
+    `| Proposed ${language} | ${escapeCell(record.proposedTranslation)} |`,
   ];
   if (record.glossaryRefs?.length > 0) {
     lines.push('', '**Glossary references**:');

--- a/scripts/i18n-quality/generate-report.mjs
+++ b/scripts/i18n-quality/generate-report.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Renders validated/<lang>/<contentType>.json into a human-readable
+ * Markdown report - the actual deliverable an admin reads to decide what
+ * to approve. Deterministic, no LLM.
+ *
+ * Usage:
+ *   node scripts/i18n-quality/generate-report.mjs --run-id <id> --language fr
+ */
+import fsx from 'fs-extra';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const { pathExists, readdir, readJson, writeFile } = fsx;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '../..');
+
+function escapeCell(text) {
+  return text.replaceAll('|', '\\|').replaceAll('\n', '<br>');
+}
+
+async function main() {
+  const { language, runId } = parseArgs(process.argv.slice(2));
+  if (!language || !runId) {
+    console.error(
+      'Usage: node generate-report.mjs --run-id <id> --language <code>',
+    );
+    process.exit(1);
+  }
+
+  const runDir = resolve(REPO_ROOT, 'reports/translation-quality', runId);
+  const validatedDir = resolve(runDir, 'validated', language);
+  if (!(await pathExists(validatedDir))) {
+    console.error(`No validated/ directory found at ${validatedDir}`);
+    process.exit(1);
+  }
+
+  const files = (await readdir(validatedDir)).filter((f) =>
+    f.endsWith('.json'),
+  );
+
+  for (const file of files) {
+    const contentType = file.replace(/\.json$/, '');
+    const records = await readJson(resolve(validatedDir, file));
+
+    const byCategory = {
+      phrasing: records.filter((r) => r.category === 'phrasing').length,
+      terminology: records.filter((r) => r.category === 'terminology').length,
+    };
+
+    const lines = [
+      `# Proposed translation-quality changes: ${language} / ${contentType}`,
+      '',
+      `Run: \`${runId}\`. ${records.length} proposed change${records.length === 1 ? '' : 's'} ` +
+        `(${byCategory.terminology} terminology, ${byCategory.phrasing} phrasing) survived the guardrail gate.`,
+      '',
+      'Nothing here has been applied to Crowdin. To approve entries, copy this ' +
+        'run\'s validated JSON, mark the entries you want with `"status": "approved"`, ' +
+        'and hand the file to `apply-translation-quality-fixes.mjs`.',
+      '',
+      '---',
+      '',
+    ];
+
+    records.forEach((record, index) => {
+      lines.push(renderRecord(record, index));
+    });
+
+    if (records.length === 0) {
+      lines.push('_No changes proposed for this content type._', '');
+    }
+
+    const outPath = resolve(validatedDir, `${contentType}.md`);
+    await writeFile(outPath, lines.join('\n'), 'utf-8');
+    console.log(`Wrote ${outPath} (${records.length} entries)`);
+  }
+}
+
+function parseArgs(argv) {
+  const args = { language: null, runId: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--language') {
+      args.language = argv[i + 1];
+      i += 1;
+    } else if (argv[i] === '--run-id') {
+      args.runId = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function renderRecord(record, index) {
+  const lines = [
+    `### ${index + 1}. \`${record.key}\` (${record.category}, confidence: ${record.confidence ?? 'unspecified'})`,
+    '',
+    `**Reason**: ${record.reason}`,
+    '',
+    '| | Text |',
+    '| --- | --- |',
+    `| English source | ${escapeCell(record.sourceEn)} |`,
+    `| Current French | ${escapeCell(record.currentTranslation)} |`,
+    `| Proposed French | ${escapeCell(record.proposedTranslation)} |`,
+  ];
+  if (record.glossaryRefs?.length > 0) {
+    lines.push('', '**Glossary references**:');
+    for (const ref of record.glossaryRefs) {
+      lines.push(
+        `- "${ref.termEn}" -> "${ref.official}"${ref.sourceUrl ? ` ([source](${ref.sourceUrl}))` : ''}`,
+      );
+    }
+  }
+  lines.push('', `_id: \`${record.id}\` | file: \`${record.filePath}\`_`, '');
+  return lines.join('\n');
+}
+
+await main();

--- a/scripts/i18n-quality/glossaries/cmn-hans.json
+++ b/scripts/i18n-quality/glossaries/cmn-hans.json
@@ -1,0 +1,257 @@
+{
+  "_comment": "Grounded JW terminology for cmn-hans (Simplified Chinese), cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-11",
+  "_language": "cmn-hans",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "耶和华见证人",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Simplified Chinese Style and Terminology Guide (用词介绍), found via the English guide's <link hreflang=\"cmn-hans\"> tag. Defines it near word-for-word matching the English guide's definition."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "王国聚会所",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide's full/formal entry is \"耶和华见证人王国聚会所\" (\"Kingdom Hall of Jehovah's Witnesses\"), explicitly noting it is commonly called \"王国聚会所\" - the short form is what a congregation-facing app should use. Avoid \"教堂\"/\"教会\" (church) per the guide's own instruction."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "分区监督",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Matches the app's own current cmn-hans.json translation (\"circuit-overseer\": \"分区监督\"). Guide notes the term is not used as an honorific title."
+    },
+    {
+      "termEn": "congregation",
+      "official": "会众",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Direct, unambiguous match - no false-friend risk found (unlike e.g. French, where the government-facing Lexique prefers a different word than congregation-facing publications)."
+    },
+    {
+      "termEn": "elder",
+      "official": "长老",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: appointed male Witness who teaches/cares for the congregation, unpaid, not a clergy title."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "长老团协调人",
+      "sourceUrls": ["https://wol.jw.org/cmn-Hans/wol/d/r23/lp-chs/1200276968"],
+      "confidence": "high",
+      "notes": "IMPORTANT: \"presiding overseer\" itself is discontinued English terminology (replaced by \"Coordinator of the Body of Elders\" starting 2008, per the parallel English Watch Tower Publications Index entry, doc 1200276968 - the same numeric ID resolves to the Chinese Publications Index via wol.jw.org's language-swap). The Chinese WOL entry for the CURRENT role, 长老团协调人 (\"长老团协调人\" formerly called 长老团统筹者, and before that 主持监督, 会众监督, 组务仆人, 服务指导员), explicitly states it \"取代'主持监督'这个名称\" (\"replaces the name 'presiding overseer'\"). So: if the app text refers to the discontinued English role/title \"presiding overseer\" verbatim, its old Chinese equivalent was 主持监督; if it refers to the elder who currently chairs/coordinates meetings (the seed's context), the correct current term is 长老团协调人. Flag either English or Chinese use of the old terms as outdated."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "助理仆人",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: appointed, spiritually mature male Witness who assists elders with non-pastoral tasks; unpaid; not an honorific title."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "先驱",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Covers both \"regular pioneer\" (正规先驱, 600 hrs/year) and \"auxiliary pioneer\" (辅助先驱, 15 or 30 hrs/month) per the guide; \"先驱\" alone is most often shorthand for regular pioneer. Not an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "传道",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's \"传道\" entry corresponds to the English guide's \"field service\" entry (cross-referenced there from \"preaching\"), describing the public ministry per Matthew 24:14; 28:19."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "耶稣牺牲纪念聚会",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/",
+        "https://www.jw.org/cmn-hans/%E5%A4%9A%E5%AA%92%E4%BD%93%E5%9B%BE%E4%B9%A6%E9%A6%86/%E4%B9%A6%E7%B1%8D/%E5%9C%A3%E7%BB%8F%E8%AF%8D%E8%AF%AD%E8%A7%A3%E9%87%8A/%E4%B8%BB%E7%9A%84%E6%99%9A%E9%A4%90/"
+      ],
+      "confidence": "high",
+      "notes": "GROUND WITH CARE (flagged as a recurring mistranslation trap across languages): the Terminology Guide's full entry is \"耶稣牺牲纪念聚会\", also called \"主的晚餐\" (Lord's Evening Meal). The Bible Glossary's \"主的晚餐\" page instead phrases the ceremony as \"耶稣受难纪念聚会\" (\"Jesus's Passion Memorial Meeting\") - jw.org itself is not perfectly consistent about 牺牲/受难. The app's own current cmn-hans.json uses the short colloquial form \"纪念聚会\" throughout (e.g. \"memorialDate\": \"纪念聚会日期\"), which is standard everyday shorthand and should NOT be flagged as wrong - treat 纪念聚会 / 耶稣牺牲纪念聚会 / 耶稣受难纪念聚会 / 主的晚餐 as all acceptable. Do flag anything using a generic secular \"memorial\" word (e.g. a monument/tombstone sense) or an unrelated discontinued-holiday term, per the pattern seen in other languages."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "会众研经班",
+      "sourceUrls": ["https://wol.jw.org/cmn-Hans/wol/d/r23/lp-chs/1200276966"],
+      "confidence": "high",
+      "notes": "Found via wol.jw.org's numeric-ID language-swap from the English Watch Tower Publications Index entry (doc 1200276966). Formerly called 书籍研究班, 会众书籍研究班, 圣经研究的庇哩亚组, 圣经研究的黎明组. Matches the app's own current cmn-hans.json translation (\"cbs\": \"会众研经班\") exactly."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "传道与生活聚会",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide's entry corresponds directly to the English guide's \"midweek meeting\" (three-part program \"Our Christian Life and Ministry\"). Literally \"the Ministry and Life meeting\"."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "公众聚会",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Corresponds to the English guide's \"Public Meeting\" entry, not a literal \"weekend meeting\" - jw.org names this meeting for its public-talk content rather than its schedule slot, matching the pattern seen in other languages (e.g. French \"réunion publique\"). Comprises the public talk (公众演讲) followed by the Watchtower Study (《守望台》研究班)."
+    },
+    {
+      "termEn": "public talk",
+      "official": "公众演讲",
+      "sourceUrls": ["https://wol.jw.org/cmn-Hans/wol/d/r23/lp-chs/1200274681"],
+      "confidence": "high",
+      "notes": "FALSE-FRIEND RISK: do not confuse with \"公开演讲\", a much older/looser phrase that mostly means \"to speak in public\" as a general verb/activity (e.g. \"要他们公开演讲，比死还可怕\" = \"having to speak in public is worse than death\") and is NOT the proper noun for this meeting segment. \"公众演讲\" is the term with its own current Watch Tower Publications Index entry (doc 1200274681, the same alphabetical-position neighbor of the English \"Public Talks\" entry, doc 1200274680) and is used as the specific label for the 30-minute talk (e.g. \"公众演讲协调人\" = \"public talk coordinator\"). Matches the app's own current cmn-hans.json exactly (\"pt\"/\"public-talk\": \"公众演讲\")."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "《守望台》研究班",
+      "sourceUrls": ["https://wol.jw.org/cmn-Hans/wol/d/r23/lp-chs/1200276170"],
+      "confidence": "high",
+      "notes": "Confirmed via a current Watch Tower Publications Index entry (references as recent as 《守》19.05 and the current \"Organized to Do Jehovah's Will\" book). Matches the app's own current cmn-hans.json exactly (\"magazine-watchtower-study\": \"《守望台》研究班版\", \"excludeFootnotes\" uses \"《守望台》研究班文章\"). Note this differs from the Terminology Guide's own looser paraphrase, which just calls the underlying magazine edition \"研读版\" (\"study edition\") without giving the meeting part itself a bolded proper name - 《守望台》研究班 is the dedicated term for the meeting segment specifically."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "《守望台》",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title per the guide is \"《守望台宣扬耶和华的王国》\" (\"The Watchtower Announcing Jehovah's Kingdom\"), explicitly \"also called《守望台》\" - matches app usage (e.g. \"magazine-watchtower-public\": \"《守望台》公众版\"). Public/Study editions: 公众版/研究班版."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "《警醒！》",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Verified verbatim including the exclamation mark. Guide gives the same publication history as the English entry: originally 《黄金时代》(1919), renamed 《安慰报》(1937), then 《警醒！》 from Aug 22, 1946."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "《新世界译本》",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Full formal title per the guide is \"《圣经新世界译本》\", explicitly \"also called《新世界译本》\" - matches the app's own current cmn-hans.json exactly (\"audio-bible-media\": \"《新世界译本》的录音\")."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Kept untranslated as \"JW Library®\" on the Chinese terminology guide page's footer, same as on the English page - proper-noun app name, per the seed's own instruction not to translate it."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "JW.ORG",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Kept as \"JW.ORG\" in Chinese content, with the page footer reading \"JW.ORG® / 耶和华见证人官方网站\" - i.e. jw.org is glossed as \"耶和华见证人官方网站\" (\"the official website of Jehovah's Witnesses\"), which matches the app's own in-context phrase \"the official website of jw.org\" almost verbatim."
+    },
+    {
+      "termEn": "songbook",
+      "official": "诗歌集",
+      "sourceUrls": ["https://wol.jw.org/cmn-Hans/wol/d/r23/lp-chs/1200277315"],
+      "confidence": "high",
+      "notes": "Confirmed via the WOL index page for the current songbook, titled \"《向耶和华高声欢唱》（诗歌集）\" (\"'Sing Out Joyfully' to Jehovah (Songbook)\"), and as a filter-facet category (\"诗歌集\") on wol.jw.org's Chinese search UI. Note the app's own current cmn-hans.json instead consistently drops \"集\" and just uses \"诗歌\" (\"songs\") in UI strings (e.g. \"from-songbook\" equivalent, \"songbook-video-caching\": \"诗歌视频缓存\") - both are acceptable; \"诗歌\" is a natural colloquial shortening, not an error."
+    },
+    {
+      "termEn": "convention",
+      "official": "大会",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "IMPORTANT: unlike English (which distinguishes \"assembly\" from \"convention\"), Chinese has no separate generic word - 大会 (\"big meeting\") is the umbrella noun for all of them, disambiguated only by a prefix: 分区大会 (circuit assembly, 1 day), 区域大会 (regional convention, 3 days), 国际大会 (international convention, 3 days, in host cities). The app's own cmn-hans.json (\"jweventSite\": \"耶和华见证人大会\" for \"Jehovah's Witnesses Conventions\") confirms bare 大会 is used for the generic/plural sense. Do not flag plain 大会 as too vague when the English says \"convention\"."
+    },
+    {
+      "termEn": "assembly",
+      "official": "分区大会",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "The guide itself cross-references generic \"大会\" to \"分区大会\" (\"assembly. See entry: circuit assembly\" in the English version), matching the seed's description of a gathering smaller than a convention (1-day, twice a year, vs. the 3-day regional/international conventions). Matches the app's own cmn-hans.json (\"分区大会\" in \"disableMediaFetching-explain\")."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "传道训练班",
+      "sourceUrls": [
+        "https://wol.jw.org/wol/finder?wtlocale=CHS&docid=1200275768&srcid=share"
+      ],
+      "confidence": "low",
+      "notes": "The English \"Theocratic Ministry School\" was discontinued in January 2016 (folded into the new \"Our Christian Life and Ministry\" midweek meeting), so there is no current jw.org terminology page for it. Its Chinese Watch Tower Publications Index entry is titled \"传道训练班（已终止）\" (\"Ministry Training Class (Discontinued)\"), formerly called 神治传道训练班 (\"Theocratic Ministry Training Class\", the more literal match for the English name) and 神治传道训练课程. The app's own current cmn-hans.json uses \"传道训练班\" for this exact seed context (\"disableMediaFetching-explain\": \"...传道训练班、分区大会等特别活动...\"), so this rendering is confirmed as what's actually in use in-app - but since the underlying program is officially discontinued/historical, and jw.org has no current authoritative page defining it, confidence is marked low. If the app text is describing a still-active current program (e.g. a pioneer service school), a different term may be correct - worth a spot check against actual app context."
+    },
+    {
+      "termEn": "sign language",
+      "official": "手语",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E8%80%B6%E5%92%8C%E5%8D%8E%E8%A7%81%E8%AF%81%E4%BA%BA/%E6%B4%BB%E5%8A%A8/%E5%87%BA%E7%89%88/%E6%89%8B%E8%AF%AD%E7%BF%BB%E8%AF%91%E5%B7%A5%E4%BD%9C/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed both by the Chinese URL slug (手语翻译工作 = \"sign language translation work\", the direct localization of the English page's \"sign-language-translation\") and by the app's own current cmn-hans.json (\"sign-language-bible\": \"手语圣经\")."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "传道与生活聚会手册",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%A4%9A%E5%AA%92%E4%BD%93%E5%9B%BE%E4%B9%A6%E9%A6%86/%E8%80%B6%E5%92%8C%E5%8D%8E%E8%A7%81%E8%AF%81%E4%BA%BA%E8%81%9A%E4%BC%9A%E6%89%8B%E5%86%8C/"
+      ],
+      "confidence": "high",
+      "notes": "Found via the English \"Our Christian Life and Ministry - Meeting Workbook\" page's <link hreflang=\"cmn-hans\" title=\"传道与生活聚会手册\"> tag. Commonly shortened in body text and WOL indexes to just \"《聚会手册》\" (e.g. issue citations like \"《聚会手册》24.07\") - both forms should be acceptable in-app."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "全年经文",
+      "sourceUrls": ["https://wol.jw.org/cmn-Hans/wol/d/r23/lp-chs/1200276311"],
+      "confidence": "high",
+      "notes": "Confirmed via the WOL index page title (\"全年经文\", the Chinese equivalent of the English \"Yeartexts\" index, doc 1200276311) and matches the app's own current cmn-hans.json exactly (\"yeartext\": \"全年经文\")."
+    },
+    {
+      "termEn": "branch office",
+      "official": "分部办事处",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: administrative center of a Branch Committee (分部委员会), supporting/supervising activity in one or more countries; \"sometimes shortened to 分部\" (matching English's \"branch\")."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "中央长老团",
+      "sourceUrls": [
+        "https://www.jw.org/cmn-hans/%E5%85%A8%E7%90%83%E4%BC%A0%E6%92%AD/%E7%94%A8%E8%AF%8D%E4%BB%8B%E7%BB%8D/"
+      ],
+      "confidence": "high",
+      "notes": "Full/formal entry per the guide is \"耶和华见证人中央长老团\" (\"Governing Body of Jehovah's Witnesses\"), explicitly \"often shortened to 中央长老团\" - the short form is what a congregation-facing app should use."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/de.json
+++ b/scripts/i18n-quality/glossaries/de.json
@@ -1,0 +1,262 @@
+{
+  "_comment": "Grounded JW terminology for de, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-11",
+  "_language": "de",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Jehovas Zeugen",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Terminologie und Ausdrucksweise: \"Eine christliche Religionsgemeinschaft, deren Mitglieder Gott Jehova anbeten...\" Guide notes it is linguistically incorrect to say \"ein Jehovas Zeuge\"/\"eine Jehovas Zeugin\" - the plural form is used for individuals too, e.g. \"ein Zeuge Jehovas\"."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Königreichssaal von Jehovas Zeugen",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to just \"Königreichssaal\" per the guide (\"Oft auch einfach 'Königreichssaal' genannt\"). Guide explicitly asks to avoid the word \"Kirche\" (church) for it."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "Kreisaufseher",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Ein erfahrener Ältester, der ... unter der Anleitung des Zweigbüros regelmäßig jede Versammlung (Gemeinde) in einem Kreis ... besucht.\" Not used as an honorific title."
+    },
+    {
+      "termEn": "congregation",
+      "official": "Versammlung",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "The guide consistently glosses \"Versammlung\" with a parenthetical \"(Gemeinde)\" throughout (e.g. \"Versammlung (Gemeinde) von Zeugen Jehovas\") to help general readers, but \"Versammlung\" alone is the term JW.org itself uses as the headword - unlike French, there is no competing official synonym here."
+    },
+    {
+      "termEn": "elder",
+      "official": "Ältester",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Ein Zeuge Jehovas (männlich), der im Glauben gefestigt ist... 'Ältester' ist kein Ehrentitel.\" Not a paid/clergy role."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "Koordinator der Ältestenschaft",
+      "sourceUrls": [
+        "https://wol.jw.org/de/wol/d/r10/lp-x/1200276968",
+        "https://wol.jw.org/de/wol/d/r10/lp-x/1200274607"
+      ],
+      "confidence": "high",
+      "notes": "Not covered by the general-audience terminology guide (an internal congregation role). Confirmed via jw.org's own Watchtower Publications Index: the index page for numeric ID 1200274607 is titled \"Vorsitzführender Aufseher (eingestellt)\" - i.e. \"Presiding Overseer (DISCONTINUED)\" - and explicitly cross-references \"(Später Koordinator der Ältestenschaft genannt)\" = \"later called Koordinator der Ältestenschaft\". The current term's own index page (ID 1200276968) confirms \"KOORDINATOR DER ÄLTESTENSCHAFT (Früher Vorsitzführender Aufseher; Versammlungsaufseher; Versammlungsdiener; Dienstleiter genannt)\". This matches the 2023 congregation-restructuring change reported for other languages - do not use \"Vorsitzführender Aufseher\", it is explicitly marked discontinued."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "Dienstamtgehilfe",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Ein im Glauben starker Zeuge Jehovas (männlich), der die Ältesten einer Versammlung (Gemeinde) bei organisatorischen und praktischen Aufgaben unterstützt.\" Not an honorific title; written as one word."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "Pionier",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide distinguishes \"allgemeiner Pionier\" (regular pioneer, 600 h/year) from \"Hilfspionier\" (auxiliary pioneer, 15-30 h/month); bare \"Pionier\" usually implies the former. Not an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "Predigtdienst",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "The guide's \"Predigen\" (preaching) entry simply redirects to \"Predigtdienst\", so the two English seed concepts (field service / preaching) map to a single German term."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Abendmahl",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/",
+        "https://www.jw.org/de/jehovas-zeugen/erinnerung-an-jesu-tod/"
+      ],
+      "confidence": "high",
+      "notes": "Grounded carefully per instructions, from two independent official pages that partly disagree on the short label, so a reviewer should treat all of these as acceptable: (1) the press-facing terminology guide gives the full descriptive name \"Feier zum Gedenken an den Tod Christi\", noting it is 'also called \"Abendmahl des Herrn\" or \"Gedächtnismahl\"'; (2) jw.org's own live Memorial landing page (fetched raw, not summarized) uses \"Abendmahl\" as its site-nav/category label (menu items \"Zusammenkünfte > Abendmahl\", section header \"ABENDMAHL\") in exactly the structural slot English uses \"Memorial\", while its running body text mostly says \"Gedenkfeier\" (e.g. \"Wie lange dauert die Gedenkfeier?\"), and an older congregation-index entry (WOL km 4/92) headed the same event \"Gedächtnismahl\". CAUTION: \"Abendmahl\" is also the generic mainstream-Christian word for the Eucharist/Lord's Supper - jw.org deliberately reuses it for its own single annual observance, so this is confirmed official usage, not a false-friend slip, but do not be surprised to see \"Gedächtnismahl\" or \"Gedenkfeier\" instead in-app; flag only something unrelated (e.g. a discontinued/generic holiday name) as wrong."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Versammlungsbibelstudium",
+      "sourceUrls": ["https://wol.jw.org/de/wol/d/r10/lp-x/1200276966"],
+      "confidence": "high",
+      "notes": "Not covered by the general-audience terminology guide. Confirmed via jw.org's Watchtower Publications Index using the cross-language numeric-ID technique (English ID 1200276966 = current \"Congregation Bible Study\" entry; the identical German ID resolves to \"VERSAMMLUNGSBIBELSTUDIUM\"). The same index page notes prior names: \"Früher Versammlungsbuchstudium; Beröer-Bibelstudium; Tagesanbruch-Bibelstudien genannt\" - do not use those older names."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "Zusammenkunft unter der Woche",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: program titled \"Unser Leben und Dienst als Christ\". Congregation-internal literature (S-38 guidelines, etc.) also calls it the \"Leben-und-Dienst-Zusammenkunft\"."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "Zusammenkunft für die Öffentlichkeit",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide describes it as including a 30-minute public talk followed by the Watchtower Study."
+    },
+    {
+      "termEn": "public talk",
+      "official": "öffentlicher Vortrag",
+      "sourceUrls": ["https://wol.jw.org/de/wol/d/r10/lp-x/1102001126"],
+      "confidence": "medium",
+      "notes": "Not a separate headword in the terminology guide (folded into the \"Zusammenkunft für die Öffentlichkeit\" definition as \"30-minütiger biblischer Vortrag\"). \"öffentlichen Vortrag\" is attested verbatim in the official elders' guidelines document \"Richtlinien für Schulaufseher\" (\"... in der Woche, in der er einen öffentlichen Vortrag in der Versammlung hält\"); an older WOL article title also uses the plural \"Öffentliche biblische Vorträge\"."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Wachtturm-Studium",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Appears inline in the terminology guide's \"Zusammenkunft für die Öffentlichkeit\" entry: \"... folgt in der Regel das Wachtturm-Studium, ein einstündiger Programmteil mit Zuhörerbeteiligung.\""
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "Der Wachtturm",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title per the guide is \"Der Wachtturm verkündigt Jehovas Königreich\"; guide says it is \"kurz auch Wachtturm genannt\". Has a public edition and a study edition; published continuously since 1879."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Erwachet!",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed verbatim, including the exclamation mark. Formerly \"The Golden Age\" (1919) and \"Consolation\" (1937) in English; adopted current name with the issue of August 22, 1946."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Neue-Welt-Übersetzung",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Full title per the guide: \"Die Bibel. Neue-Welt-Übersetzung\"; can be shortened to \"Neue-Welt-Übersetzung\"."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Proper-noun app name, not translated - confirmed as-is verbatim in the German jw.org page's own footer navigation, consistent with the seed's instruction."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Domain/proper noun kept as-is; rendered \"JW.ORG\" in the logo/brand lockup (all caps) and lowercase \"jw.org\" in running/copyright text. Site tagline: \"OFFIZIELLE WEBSITE VON JEHOVAS ZEUGEN\" - matching the app's own phrase \"the official website of jw.org\"."
+    },
+    {
+      "termEn": "songbook",
+      "official": "Liederbuch",
+      "sourceUrls": [
+        "https://wol.jw.org/de/wol/d/r10/lp-x/1200027263",
+        "https://wol.jw.org/de/wol/publication/r10/lp-x/sn/136"
+      ],
+      "confidence": "medium",
+      "notes": "\"Liederbuch\"/\"Liederbücher\" is the generic category label used in jw.org's own publications index. Not a terminology-guide entry. The current specific songbook in active use is \"Singt Lieder für Jehova\" (publication symbol \"sn\", 135+ songs, periodically extended with \"neue Lieder\"), which superseded the older \"Singt Jehova Loblieder\" (1986) and \"Singt und spielt dabei Jehova in euren Herzen\" (1969). If the app's string names a specific book rather than the generic noun, \"Singt Lieder für Jehova\" is more likely what appears."
+    },
+    {
+      "termEn": "convention",
+      "official": "Kongress",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's \"Kongress\" entry redirects to the specific types: \"Internationaler Kongress\" (3-day, annual, rotating host cities) and \"Regionaler Kongress\" (3-day, annual, regional). Either compound is a valid rendering of \"convention\" depending on context; see the \"assembly\" entry for the smaller \"Kreiskongress\"."
+    },
+    {
+      "termEn": "assembly",
+      "official": "Kreiskongress",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Ganztägiger Gottesdienst mehrerer Versammlungen (Gemeinden) von Jehovas Zeugen, der zweimal im Jahr abgehalten wird\" - a one-day, twice-yearly circuit-level meeting, matching the seed's \"smaller than a convention\" sense (English's \"circuit assembly\"). Note German folds this into the \"Kongress\" family of compounds rather than using an unrelated word."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "Theokratische Predigtdienstschule",
+      "sourceUrls": ["https://wol.jw.org/de/wol/d/r10/lp-x/1102001126"],
+      "confidence": "medium",
+      "notes": "Not in the current terminology guide. This was a weekly training program within the pre-2016 midweek meeting structure (discontinued when the \"Life and Ministry\" meeting format was introduced), documented in older Watchtower Library material such as \"Richtlinien für Schulaufseher\". If the app's usage refers to a still-active training program held in connection with assemblies/conventions rather than this legacy weekly school, verify against current app context before relying on this rendering."
+    },
+    {
+      "termEn": "sign language",
+      "official": "Gebärdensprache",
+      "sourceUrls": ["https://wol.jw.org/de/wol/d/r10/lp-x/1200275321"],
+      "confidence": "high",
+      "notes": "Generic, well-established German word; confirmed as a Watchtower Publications Index headword (\"GEBÄRDENSPRACHE\", cross-referencing \"Amerikanische Gebärdensprache\", \"Gehörlose\"). Not a dedicated terminology-guide entry."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Unser Leben und Dienst als Christ: Arbeitsheft",
+      "sourceUrls": ["https://wol.jw.org/de/wol/d/r10/lp-x/202025000"],
+      "confidence": "high",
+      "notes": "Full title of the Our Christian Life and Ministry Meeting Workbook, confirmed via multiple dated jw.org/WOL editions (e.g. \"...Arbeitsheft, Januar/Februar 2025\"). \"Arbeitsheft\" alone is the generic term for \"workbook\"."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "Jahrestext",
+      "sourceUrls": [
+        "https://wol.jw.org/de/wol/d/r10/lp-x/1200028490",
+        "https://wol.jw.org/de/wol/d/r10/lp-x/1200276311"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via Watchtower Publications Index headwords \"JAHRESTEXT\" (singular concept entry) and \"JAHRESTEXTE\" (plural, chronological list of every yeartext back to 1915)."
+    },
+    {
+      "termEn": "branch office",
+      "official": "Zweigbüro",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Örtlicher Verwaltungssitz des jeweiligen Zweigkomitees ... Manchmal auch 'Zweig' genannt.\" Related term \"Zweigkomitee\" = Branch Committee."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Leitende Körperschaft von Jehovas Zeugen",
+      "sourceUrls": [
+        "https://www.jw.org/de/informationen-fuer-behoerden-medien-wissenschaft/terminologie-und-ausdrucksweise/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Eine kleine Gruppe von Ältesten, die die geistliche Leitung von Jehovas Zeugen weltweit bildet.\" Commonly shortened to \"Leitende Körperschaft\". Offices located at the World Headquarters in Warwick, New York."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/es.json
+++ b/scripts/i18n-quality/glossaries/es.json
@@ -1,0 +1,258 @@
+{
+  "_comment": "Grounded JW terminology for es, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-11",
+  "_language": "es",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "testigos de Jehová",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Terminología y estilo (jw.org's own style/terminology guide) consistently renders this lowercase in running text: \"El nombre testigos de Jehová los distingue de otras religiones...\". The abbreviated form used after first mention is capitalized: \"los Testigos\" / \"un Testigo\". Do not flag lowercase \"testigos de Jehová\" as a casing error - it is jw.org's own preferred style, unlike the English capitalized \"Jehovah's Witnesses\"."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Salón del Reino",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Full official form per the guide is \"Salón del Reino de los Testigos de Jehová\", explicitly shortened in the same entry to \"Salón del Reino\". The guide also notes to avoid the term \"iglesia\" (church) for it."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "superintendente de circuito",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Anciano de experiencia que sirve bajo la dirección de una sucursal y que visita todas las congregaciones de un circuito, normalmente dos veces al año.\" The guide also explicitly says this expression is not used as an honorific title."
+    },
+    {
+      "termEn": "congregation",
+      "official": "congregación",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Grupo organizado de Testigos que se reúne regularmente para adorar a Dios.\" Unlike French, there is no false-friend risk here - Spanish \"congregación\" is the plain, unambiguous everyday term."
+    },
+    {
+      "termEn": "elder",
+      "official": "anciano",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Testigo varón maduro en sentido espiritual a quien se le nombra para enseñar y cuidar a quienes forman parte de la congregación.\" Guide notes elders receive no salary and the term is not used as an honorific title."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "superintendente presidente",
+      "sourceUrls": ["https://wol.jw.org/es/wol/d/r4/lp-s/1200274607"],
+      "confidence": "medium",
+      "notes": "Not covered by jw.org's public Terminología y estilo guide (an internal congregation role, not explained to media). Confirmed via a Watch Tower Publications Index entry, but that entry's own heading is \"Superintendente presidente (descontinuado)\" - i.e. jw.org itself now marks this role/title as discontinued, with predecessor names \"superintendente de congregación\", \"siervo de congregación\", \"director de servicio\", and successor \"coordinador del cuerpo de ancianos\" (coordinator of the body of elders). If the app's context is current rather than historical, \"coordinador del cuerpo de ancianos\" is likely the more accurate present-day equivalent - flag for reviewer judgment based on surrounding context."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "siervo ministerial",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Testigo varón maduro en sentido espiritual a quien se le nombra para ayudar a los ancianos en algunas tareas del cuidado de la congregación.\" Not used as an honorific title, per the guide."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "precursor, precursora",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide distinguishes \"precursor regular\" (600 hours/year, 50/month) from \"precursor auxiliar\" (15 or 30 hours in a given month). Feminine form \"precursora\" given explicitly. Not used as an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "predicación",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "IMPORTANT: the guide's own \"ministerio del campo\" entry is a redirect stub: \"ministerio del campo. Ver la entrada predicar, predicación.\" - i.e. jw.org now steers away from the older literal calque \"ministerio del campo\" (field ministry) in favor of \"predicar, predicación\" (to preach, preaching). If the app currently uses \"ministerio del campo\" for this seed term, that is likely a stale/older rendering rather than an outright error - it was jw.org's own earlier term."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Conmemoración de la muerte de Cristo",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide gives the full form plus several accepted synonyms in the same entry: \"Cena del Señor, última cena, Conmemoración, Conmemoración de la muerte de Jesús.\" Congregation-facing content very commonly shortens this to just \"la Conmemoración\", matching the seed's short English form \"Memorial\"."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Estudio Bíblico de la Congregación",
+      "sourceUrls": ["https://wol.jw.org/es/wol/d/r4/lp-s/1200276966"],
+      "confidence": "high",
+      "notes": "Not in the public Terminología y estilo guide (internal meeting-part name). Confirmed verbatim as a Watch Tower Publications Index heading, found by substituting the language segment into the equivalent English wol.jw.org numeric-ID URL (https://wol.jw.org/en/wol/d/r1/lp-e/1200276966). Historical predecessor names listed on the same page: \"Estudio de Libro de Congregación\", \"Círculos Bereanos para Estudios Bíblicos\", \"Círculos de la Aurora para Estudios Bíblicos\"."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "reunión de entre semana",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Reunión semanal de la congregación que generalmente se celebra por la noche un día entre semana. La reunión se llama Vida y Ministerio Cristianos y se divide en tres partes.\""
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "reunión de fin de semana",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Reunión semanal de la congregación que generalmente se celebra un día de fin de semana. Normalmente tiene dos partes\" - a 30-minute public talk followed by the hour-long Watchtower Study."
+    },
+    {
+      "termEn": "public talk",
+      "official": "discurso público",
+      "sourceUrls": [
+        "https://wol.jw.org/es/wol/d/r4/lp-s/1200274680",
+        "https://www.jw.org/es/biblioteca/revistas/g20010522/Venga-y-escuche-el-discurso-p%C3%BAblico/"
+      ],
+      "confidence": "high",
+      "notes": "Not a separate headword in the Terminología y estilo guide (folded into the \"reunión de fin de semana\" entry as \"un discurso bíblico de 30 minutos\"). \"Discurso público\" (plural index heading: \"Discursos públicos\") is the well-attested standing term across wol.jw.org and jw.org magazine content; the WOL index page itself notes the meeting segment was formerly called \"Reunión Pública\"."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Estudio de La Atalaya",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide (within the \"reunión de fin de semana\" entry), quoted verbatim: \"la segunda parte, que se llama Estudio de La Atalaya y dura una hora, se analiza un tema de la Biblia mediante preguntas y respuestas usando un artículo de la edición de estudio de la revista La Atalaya.\""
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "La Atalaya. Anunciando el Reino de Jehová",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title per the guide, punctuated with a period as shown. Congregation-facing and everyday usage overwhelmingly shortens this to just \"La Atalaya\" (also confirmed used bare throughout the same guide entry)."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "¡Despertad!",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed verbatim on the guide, including both the opening inverted and closing exclamation marks (Spanish orthography). Guide notes the magazine's earlier English names: The Golden Age (1919), Consolation (1937), before becoming Awake! in 1946."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Traducción del Nuevo Mundo",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title per the guide is \"La Biblia. Traducción del Nuevo Mundo\" (punctuated with a period); the guide itself notes this is \"muchas veces\" shortened to just \"Traducción del Nuevo Mundo\"."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed not translated - \"JW Library\" appears verbatim (with ® mark) in the Spanish jw.org site's own footer navigation, consistent with the seed's own instruction not to translate the app name."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Domain/proper noun kept as-is. The Spanish jw.org site's own footer branding reads \"JW.ORG® / SITIO OFICIAL DE LOS TESTIGOS DE JEHOVÁ\", matching the app's in-context phrase \"the official website of jw.org\" -> \"el sitio oficial de jw.org\"."
+    },
+    {
+      "termEn": "songbook",
+      "official": "cancionero",
+      "sourceUrls": ["https://wol.jw.org/es/wol/d/r4/lp-s/1200275422"],
+      "confidence": "high",
+      "notes": "Confirmed as the generic category label via a Watch Tower Publications Index heading (\"Cancioneros\", plural). The current active songbook title is \"Cantemos a Jehová\" (a book, not itself called a \"cancionero\" in its title); older editions cross-referenced on the same index page include \"Canten alabanzas a Jehová\", \"Cantemos con gozo a Jehová\", and \"Cánticos de alabanza a Jehová\" (1928/1950)."
+    },
+    {
+      "termEn": "convention",
+      "official": "asamblea regional / asamblea internacional",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "medium",
+      "notes": "IMPORTANT: Spanish has no standalone word equivalent to English \"convention\" in this sense - jw.org always uses \"asamblea\" plus a qualifier. Per the guide: \"asamblea regional\" = annual 3-day gathering of several congregations in one region (large rented venues, e.g. stadiums); \"asamblea internacional\" = annual 3-day gathering in various world cities with international attendance. Either may be the intended match depending on scale - do not flag a translation using \"asamblea\" instead of a literal \"convención\" as wrong (\"convención\" is not jw.org's own usage for its own events)."
+    },
+    {
+      "termEn": "assembly",
+      "official": "asamblea de circuito",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"asamblea de circuito. Reunión de un día de varias congregaciones de los testigos de Jehová. Se celebran dos veces al año\" - matches the seed's description of a gathering smaller than a convention. The guide's umbrella entry \"asamblea\" (see also \"convention\" entry) covers all three sub-types: de circuito, internacional, regional."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "escuela teocrática",
+      "sourceUrls": [
+        "https://wol.jw.org/es/wol/d/r4/lp-s/1200275768",
+        "https://wol.jw.org/es/wol/d/r4/lp-s/2012686"
+      ],
+      "confidence": "medium",
+      "notes": "Not in the Terminología y estilo guide. \"Escuela teocrática\" (plural \"escuelas teocráticas\") is well attested as a generic descriptor across decades of jw.org/WOL content for the organization's various specialized training courses (e.g. \"Las escuelas teocráticas: una demostración del amor de Jehová\"). The specific weekly congregation program formerly named \"Escuela del Ministerio Teocrático\" is itself now marked \"(descontinuada)\" in the Watch Tower Publications Index, having been folded into the midweek meeting restructuring. Given the app's own context (\"special events such as theocratic schools, assemblies, or conventions\"), the generic lowercase \"escuela teocrática\" is the more likely intended sense rather than the discontinued proper-noun program."
+    },
+    {
+      "termEn": "sign language",
+      "official": "lengua de señas",
+      "sourceUrls": ["https://wol.jw.org/es/wol/d/r4/lp-s/1200275321"],
+      "confidence": "high",
+      "notes": "Confirmed as a Watch Tower Publications Index heading (\"Lengua de señas\"), found via the wol.jw.org numeric-ID cross-language trick. \"Lenguaje de señas\" is also used interchangeably in some jw.org body text/page titles, but \"lengua de señas\" is the index/glossary-preferred form."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Guía de actividades para la reunión Vida y Ministerio Cristianos",
+      "sourceUrls": ["https://wol.jw.org/es/wol/d/r4/lp-s/1200277262"],
+      "confidence": "high",
+      "notes": "Confirmed verbatim as a Watch Tower Publications Index heading. The same index cross-references a shortened generic form, \"Guía de actividades\", which is what appears in monthly issue titles (e.g. \"Guía de actividades para la reunión Vida y Ministerio Cristianos (enero y febrero de 2024)\") - either full or short form should be acceptable in-app."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "texto del año",
+      "sourceUrls": ["https://wol.jw.org/es/wol/d/r4/lp-s/1200276311"],
+      "confidence": "high",
+      "notes": "Confirmed via a Watch Tower Publications Index heading (\"Texto del año\") listing every year's text back to 1915. Example: the 2025 yeartext is rendered \"Denle a Jehová la gloria que su nombre merece\" (Salmo 96:8)."
+    },
+    {
+      "termEn": "branch office",
+      "official": "sucursal",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Sede administrativa local de un Comité de Sucursal, desde donde se coordinan y supervisan las actividades religiosas de los testigos de Jehová en uno o más países.\" The guide's separate \"Betel\" entry notes this is also a common informal synonym for the branch facility/staff."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Cuerpo Gobernante de los Testigos de Jehová",
+      "sourceUrls": [
+        "https://www.jw.org/es/comunicados-internacionales/terminolog%C3%ADa-estilo/"
+      ],
+      "confidence": "high",
+      "notes": "Guide gives the full form and notes it is \"con frecuencia\" shortened to just \"Cuerpo Gobernante\". Defined as \"Pequeño grupo de ancianos nombrados para atender en sentido espiritual a los testigos de Jehová de todo el mundo\", based at the world headquarters in Warwick, New York."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/et.json
+++ b/scripts/i18n-quality/glossaries/et.json
@@ -1,0 +1,262 @@
+{
+  "_comment": "Grounded JW terminology for et, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-11",
+  "_language": "et",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Jehoova tunnistajad",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Jehoova tunnistajad. Kristlik usuliikumine. Jehoova tunnistajad usuvad, et Jumala nimi on Jehoova ja tema poeg on Jeesus Kristus...\" Also used as the page's own site name (<h2 id=\"siteName\">Jehoova tunnistajad</h2>). Guide asks not to use \"jehovistid\", \"jehoovakad\" or \"jehoovad\"."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Jehoova tunnistajate kuningriigisaal",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"kuningriigisaal. Jehoova tunnistajate koosolekupaik, mida kasutab üks või mitu kogudust. Ametlik nimetus on Jehoova tunnistajate kuningriigisaal. Palun ärge kasutage selle kohta terminit „kirik”.\" Commonly shortened to just \"kuningriigisaal\"."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "ringkonnaülevaataja",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Kogenud kogudusevanem, kes külastab koos oma naisega (kui ta on abielus) kaks korda aastas igat kogudust oma ringkonnas.\" Term is not used as an honorific title."
+    },
+    {
+      "termEn": "congregation",
+      "official": "kogudus",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Samas paikkonnas elavad Jehoova tunnistajad, kes jumalateenimiseks regulaarselt kokku tulevad.\""
+    },
+    {
+      "termEn": "elder",
+      "official": "kogudusevanem",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Meessoost Jehoova tunnistaja, kes on määratud kogudust õpetama ja selle eest hoolt kandma.\" Not paid, not clergy; term is not used as an honorific."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "juhtiv ülevaataja",
+      "sourceUrls": [
+        "https://wol.jw.org/et/wol/d/r37/lp-st/1200274607",
+        "https://wol.jw.org/et/wol/d/r37/lp-st/1200276968"
+      ],
+      "confidence": "medium",
+      "notes": "IMPORTANT: this role's English name changed after the 2023 congregation restructuring. jw.org's Watch Tower Publications Index marks the Estonian entry at id 1200274607 as \"JUHTIV ÜLEVAATAJA (nimetus muutunud)\" - \"Presiding Overseer (name changed)\" - listing prior names \"koguduse ülevaataja, kogudusesulane, teenistusjuhataja\". The current replacement role/term (id 1200276968, matching English \"Coordinator of Body of Elders\") is \"Vanematekogu koordineerija\". Neither term appears in the current jw.org terminology guide (which likewise omits \"presiding overseer\"/\"coordinator\" in English) - found only via the wol.jw.org cross-language numeric-ID trick. A reviewer should check whether the app string actually means the old or new role before trusting either rendering."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "koguduseabiline",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Meessoost Jehoova tunnistaja, kelle ülesanne on aidata kogudusevanemaid.\" Not paid; term is not used as an honorific."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "pioneer",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Ristitud Jehoova tunnistaja, kes on otsustanud pühendada aasta jooksul kindla arvu tunde misjonitööle.\" Spelled identically to the English word. Covers \"üldpioneer\" (regular pioneer, 600 h/year) and \"abipioneer\" (auxiliary pioneer, 15 or 30 h/month). Not used as an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "kuulutustöö",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"kuulutustöö. Misjonitöö, mida Jehoova tunnistajad teevad, et täita Jeesuse käsku kuulutada „head sõnumit kuningriigist ... kogu maailmas...\""
+    },
+    {
+      "termEn": "Memorial",
+      "official": "mälestusõhtu",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Jeesus Kristuse surma-aastapäeva tähistamine. Nimetatakse ka Issanda õhtusöömaajaks ja pühaks õhtusöömaajaks.\" Described as the year's most important event, the only ceremony Jesus commanded be observed."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Koguduse piibliuurimine",
+      "sourceUrls": ["https://wol.jw.org/et/wol/d/r37/lp-st/1200276966"],
+      "confidence": "high",
+      "notes": "Watch Tower Publications Index entry, title \"KOGUDUSE PIIBLIUURIMINE\", found by substituting the Estonian language segment (r37/lp-st) into the identical English numeric id 1200276966 (\"Congregation Bible Study\"). Notes prior names \"koguduse raamatu-uurimine, Beroia piibliuurimisringid, Koidiku piibliuurimisringid\", matching the English page's \"Congregation Book Study, Berean Circles for Bible Study, Dawn Circles for Bible Study\"."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "nädalasisene koosolek",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Iganädalane koguduse koosolek. Nimetatakse ka „Kristliku elu ja teenistuse” koosolekuks. Toimub tavaliselt mõne tööpäeva õhtul kuningriigisaalis...\""
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "üldsusele suunatud koosolek",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Iganädalane koguduse koosolek, mis toimub tavaliselt nädalavahetusel kuningriigisaalis ... Seal esitatakse 30-minutine kõne ... Sellele järgneb Vahitorni-uurimine...\" - matches the English guide's \"Public Meeting\" entry structure exactly (30-minute talk followed by the Watchtower Study)."
+    },
+    {
+      "termEn": "public talk",
+      "official": "avalik kõne",
+      "sourceUrls": [
+        "https://wol.jw.org/et/wol/d/r37/lp-st/1102014937",
+        "https://wol.jw.org/et/wol/d/r37/lp-st/1200274680"
+      ],
+      "confidence": "high",
+      "notes": "No standalone headword in the terminology guide itself (the English guide likewise folds this into its \"Public Meeting\" entry rather than giving \"public talk\" its own entry). Confirmed instead in running prose on an official wol.jw.org article: \"Kui leidub piisavalt kõnepidajaid, peetakse koguduses avalik kõne iga nädal.\" Cross-referenced via the Publications Index entry at id 1200274680 (\"AVALIKUD KÕNED\", plural), matching English \"Public Talks\" at the same numeric id."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Vahitorni-uurimine",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Appears verbatim inside the terminology guide's \"üldsusele suunatud koosolek\" (weekend meeting) entry: \"Sellele järgneb Vahitorni-uurimine: ühetunnine küsimuste-vastuste vormis piibliteemaline arutelu, mille aluseks on artikkel ajakirjast Vahitorn.\" It is not given its own bolded headword, but is the term used on the authoritative page itself."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "Vahitorn",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Vahitorn. Peamine ajakiri, mida Jehoova tunnistajad välja annavad ja levitavad. Täisnimi on Vahitorn Kuulutab Jehoova Kuningriiki.\" Published since 1879."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Ärgake!",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"Ärgake!. Ajakiri, mida Jehoova tunnistajad välja annavad ja levitavad. See hakkas ilmuma aastal 1919 ja kandis tollal nime Kuldne Aeg. 1937. aastal sai selle ajakirja nimeks Lohutus. Praegune nimi Ärgake! on kasutusel alates 1946. aasta 22. augusti numbrist.\" Includes the exclamation mark as part of the proper noun, matching English usage."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Uue maailma tõlge",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"„Uue maailma tõlge”. Piiblitõlge, mille Jehoova tunnistajad on tõlkinud ja välja andnud. ... Täispikk pealkiri on „Piibel. Uue maailma tõlge”.\""
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/et/v%C3%B5rguspikker/jw-library/android/"
+      ],
+      "confidence": "high",
+      "notes": "App name kept untranslated in Estonian, same as in English. Found via the English JW Library Android help page's own hreflang=\"et\" alternate link, whose title attribute reads \"JW Library Androidi™ seadmele\" - the app name itself is left as \"JW Library\"."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": ["https://www.jw.org/et/"],
+      "confidence": "high",
+      "notes": "Domain/brand name, not translated in any language - the Estonian site itself brands as \"JW.ORG\" (e.g. footer tagline \"JW.ORG® / JEHOOVA TUNNISTAJATE AMETLIK VEEBISAIT\")."
+    },
+    {
+      "termEn": "songbook",
+      "official": "laulik",
+      "sourceUrls": [
+        "https://wol.jw.org/et/wol/d/r37/lp-st/1200277041",
+        "https://www.jw.org/et/raamatukogu/muusika-laulud/laulgem-roomsalt-jehoovale/"
+      ],
+      "confidence": "high",
+      "notes": "Publications Index entry at id 1200277041 titled \"„LAULGE JEHOOVALE” (laulik)\", cross-referenced to the identical English numeric id titled \"Sing to Jehovah (Songbook)\" - confirms laulik = songbook. The current (2025-) songbook is titled \"Laulgem rõõmsalt Jehoovale!\", confirmed via the English \"'Sing Out Joyfully' to Jehovah\" library page's hreflang=\"et\" alternate link."
+    },
+    {
+      "termEn": "convention",
+      "official": "üldkokkutulek",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's \"üldkokkutulek\" entry matches the English guide's \"regional convention\" (annual three-day event, open to public). jw.org also has a larger \"rahvusvaheline kokkutulek\" (international convention); both share the generic root \"kokkutulek\". Per the seed list's own framing (convention = larger, assembly = smaller), \"üldkokkutulek\" is the best match for generic app strings labeled \"convention\"."
+    },
+    {
+      "termEn": "assembly",
+      "official": "ringkondlik kokkutulek",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's \"ringkondlik kokkutulek\" entry matches the English guide's \"circuit assembly\" (one-day meeting held twice yearly) - smaller than \"üldkokkutulek\" (convention), matching the seed list's own size distinction."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "teokraatlik kool",
+      "sourceUrls": ["https://wol.jw.org/et/wol/d/r37/lp-st/1200277115"],
+      "confidence": "medium",
+      "notes": "Not present in the terminology guide (English or Estonian). Only found as a Publications Index umbrella entry, id 1200277115, titled \"TEOKRAATLIKUD KOOLID\" (plural), cross-referenced to the identical English id \"Theocratic Schools\" - this covers several distinct, now-discontinued historical training programs (Theocratic Ministry School, Kingdom Ministry School, etc.), not one single current named program. The singular \"teokraatlik kool\" is a reasonable literal derivation from the plural index title rather than a directly confirmed dedicated headword."
+    },
+    {
+      "termEn": "sign language",
+      "official": "viipekeel",
+      "sourceUrls": ["https://wol.jw.org/et/wol/d/r37/lp-st/1200275321"],
+      "confidence": "high",
+      "notes": "Publications Index entry at id 1200275321 titled \"Viipekeel\", cross-referenced to the identical English numeric id titled \"Sign Language (Deaf)\". \"Eesti viipekeel\" (Estonian Sign Language) is the standard compound for the specific national sign language."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "„Kristliku elu ja teenistuse” koosoleku töövihik",
+      "sourceUrls": [
+        "https://wol.jw.org/et/wol/d/r37/lp-st/1200277265",
+        "https://wol.jw.org/et/wol/d/r37/lp-st/202025160"
+      ],
+      "confidence": "high",
+      "notes": "Publications Index entry at id 1200277265 titled \"„Kristliku elu ja teenistuse” koosoleku töövihik\", matching the identical English id \"Life and Ministry Meeting Workbook\". Confirmed further by a specific dated issue at id 202025160: \"„Kristliku elu ja teenistuse” koosoleku töövihik, mai–juuni 2025\", matching English \"Our Christian Life and Ministry—Meeting Workbook, May-June 2025\" at the same id."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "aastatekst",
+      "sourceUrls": ["https://wol.jw.org/et/wol/d/r37/lp-st/1200276311"],
+      "confidence": "high",
+      "notes": "Publications Index entry at id 1200276311 titled \"AASTATEKSTID\" (plural), cross-referenced to the identical English numeric id titled \"Yeartexts\". Singular \"aastatekst\" derived via the standard Estonian -d plural suffix; not separately confirmed in running prose, since the specific dated yeartext article tried (id 301974007) 404s under the Estonian site."
+    },
+    {
+      "termEn": "branch office",
+      "official": "harubüroo",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"harubüroo. Kohalik halduskeskus, kus koordineeritakse Jehoova tunnistajate usulist tegevust ühes või mitmes riigis.\""
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "juhtiv kogu",
+      "sourceUrls": [
+        "https://www.jw.org/et/rahvusvaheline-kommunikatsioon/terminite-selgitused/"
+      ],
+      "confidence": "high",
+      "notes": "Guide: \"juhtiv kogu. Väike rühm kogudusevanemaid, kelle ülesandeks on koordineerida Jehoova tunnistajate usulist tegevust kogu maailmas. ... Juhtiv kogu asub Jehoova tunnistajate peakorteris Warwickis New Yorgi osariigis USA-s.\""
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/fr.json
+++ b/scripts/i18n-quality/glossaries/fr.json
@@ -1,0 +1,252 @@
+{
+  "_comment": "Grounded JW terminology for fr, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "fr",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Témoins de Jéhovah",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Lexique defines it as \"Groupe religieux chrétien dont les membres adorent Jéhovah Dieu et diffusent activement l'enseignement contenu dans la Bible.\""
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Salle du Royaume",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/",
+        "https://wol.jw.org/fr/wol/d/r30/lp-f/301995012"
+      ],
+      "confidence": "high",
+      "notes": "Official/media-facing Lexique gives the full form \"salle du Royaume des Témoins de Jéhovah\"; congregation-facing publications consistently shorten this to \"Salle du Royaume\"."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "responsable de circonscription",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/",
+        "https://wol.jw.org/fr/wol/d/r30/lp-f/1200271237"
+      ],
+      "confidence": "high",
+      "notes": "Current official term per both the Lexique (\"Ancien expérimenté qui, sous la conduite de la filiale, visite en général deux fois par an chaque assemblée d'une circonscription\") and a WOL index heading. \"Surveillant de circonscription\" is an older, superseded French title (listed among historical names on the WOL page) - watch for it as a stale translation."
+    },
+    {
+      "termEn": "congregation",
+      "official": "congrégation",
+      "sourceUrls": [
+        "https://wol.jw.org/fr/wol/d/r30/lp-f/201984244",
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "IMPORTANT false-friend risk: the official government/media Lexique defines \"congregation\" as \"assemblée locale\", not \"congrégation\" - and jw.org also uses bare \"assemblée\" to mean congregation in some official/formal text (e.g. an index heading renders \"Congregation Bible Study\" as \"étude biblique de l'assemblée\"). Everyday congregation-facing publications overwhelmingly use \"congrégation\" instead, which is almost certainly what the app should use, but a reviewer should not flag \"assemblée locale\" as wrong if encountered - and should double check any use of plain \"assemblée\" to make sure it isn't ambiguous with assembly/convention senses (see \"convention\"/\"assembly\" entries)."
+    },
+    {
+      "termEn": "elder",
+      "official": "ancien",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Lexique: \"Homme Témoin de Jéhovah, exercé dans la doctrine, choisi pour enseigner et prendre soin de l'assemblée [= la congrégation].\""
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "surveillant-président",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/301995012"],
+      "confidence": "medium",
+      "notes": "Not covered by jw.org's Lexique (an internal congregation role, not explained to media). Found used on a WOL congregation-history page (\"frère Sahaï a été nommé directeur de groupe (surveillant-président)\"). Could not cross-check against a second independent source, and note the underlying English role/title has reportedly evolved in recent years (\"coordinator of the body of elders\"), so this may not reflect the very latest usage - worth a fresh spot-check if precision matters."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "serviteur ministériel",
+      "sourceUrls": [
+        "https://wol.jw.org/fr/wol/d/r30/lp-f/301995012",
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "\"Serviteur ministériel\" is the term used throughout congregation/publication content (e.g. \"les anciens et les serviteurs ministériels\"). Note the Lexique (aimed at journalists/officials) instead uses a plain-language gloss, \"assistant\" (\"Homme ... choisi pour aider les anciens dans des tâches pratiques\") - an app is far more likely to use \"serviteur ministériel\"."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "pionnier",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Lexique: \"Terme utilisé pour un Témoin baptisé qui s'engage à consacrer à l'évangélisation publique un certain nombre d'heures.\""
+    },
+    {
+      "termEn": "field service",
+      "official": "service du champ",
+      "sourceUrls": [
+        "https://wol.jw.org/fr/wol/d/r30/lp-f/201977088",
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "\"Service du champ\" is the term historically and currently used in congregation-facing content (e.g. \"réunions pour le service du champ\", \"Sujets de conversation pour le service du champ\"). Note jw.org's Lexique does not have a separate \"field service\" entry at all - it merges English's \"Field service\" and \"Preaching\" into one French entry, \"prédication, ou ministère\" (\"L'activité des Témoins de Jéhovah consistant à faire connaître leurs croyances\"). Either \"service du champ\" or \"prédication\"/\"ministère\" could plausibly appear in-app depending on register."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Mémorial",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Full official name per the Lexique is \"Mémorial du sacrifice de Jésus\" (\"Commémoration annuelle du sacrifice de Jésus Christ\"); congregation content commonly shortens this to just \"le Mémorial\", matching the seed's short English form."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "étude biblique de la congrégation",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/1200276966"],
+      "confidence": "medium",
+      "notes": "Not covered by the Lexique. A WOL index page for this exact meeting part is titled \"ÉTUDE BIBLIQUE DE L'ASSEMBLÉE\" (using \"assemblée\" in its congregation sense - see the \"congregation\" entry's false-friend note), with \"étude de livre de la congrégation\" listed as a formerly-used name. Search results paraphrasing current meeting-workbook text used \"étude biblique de la congrégation\", which is likely closer to what appears in the app, but this could not be independently verified verbatim from a fetched page - worth a spot check if precision matters."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "réunion de semaine",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Lexique: \"Réunion hebdomadaire de l'assemblée [= la congrégation] locale tenue généralement un soir de semaine.\" Confirmed independently by a matching WOL index heading (\"RÉUNION DE SEMAINE\"). A variant \"réunion de milieu de semaine\" also appears in some body text but the Lexique's \"réunion de semaine\" is the canonical short form."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "réunion publique",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/",
+        "https://wol.jw.org/fr/wol/d/r30/lp-f/1200277375"
+      ],
+      "confidence": "high",
+      "notes": "Lexique: \"Réunion hebdomadaire de l'assemblée locale tenue généralement le week-end durant laquelle est présenté un discours biblique de 30 minutes.\" A WOL index heading instead uses \"RÉUNION DE WEEK-END\" for the same meeting - this more literal/colloquial form is plausibly what a scheduling-oriented app like this one actually displays, so treat both as acceptable and check app context."
+    },
+    {
+      "termEn": "public talk",
+      "official": "discours public",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/202009287"],
+      "confidence": "medium",
+      "notes": "Not a separate Lexique entry (folded into the \"réunion publique\" definition as \"un discours biblique de 30 minutes\"). \"Discours public\" is well attested in congregation content as the name of this meeting segment."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "étude de la Tour de Garde",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/1102014937"],
+      "confidence": "medium",
+      "notes": "Not a Lexique entry. Attested via search-indexed jw.org content describing the second half of the weekend meeting; could not fetch a page quoting the exact phrase verbatim, so treat as reasonably but not fully confirmed."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "La Tour de Garde annonce le Royaume de Jéhovah",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title per the Lexique (\"Principale revue publiée et diffusée par les Témoins de Jéhovah\"). In-app and everyday usage almost always shortens this to \"La Tour de Garde\"."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Réveillez-vous !",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed verbatim, including the exclamation mark, on the Lexique. Note French convention requires a space before \"!\" (\"Réveillez-vous !\"). Formerly published as \"L'Âge d'Or\" (1924) per the same entry."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "La Bible. Traduction du monde nouveau",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Current title per the Lexique. Older jw.org/WOL content uses the pre-revision full title \"Les Saintes Écritures — Traduction du monde nouveau\"; both refer to the same Bible translation, but the Lexique's shorter modern title is likely the current standard."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": ["https://www.jw.org/en/online-help/jw-library/"],
+      "confidence": "high",
+      "notes": "App/proper-noun name is not translated in French jw.org content, consistent with the seed's own instruction not to translate it."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": ["https://www.jw.org/fr/"],
+      "confidence": "high",
+      "notes": "Domain/proper noun kept as-is; the French site's own title tag reads \"Les Témoins de Jéhovah : site officiel | jw.org | Français\", and elsewhere jw.org is introduced as \"le site officiel des Témoins de Jéhovah\" - matching the app's in-context phrase \"the official website of jw.org\"."
+    },
+    {
+      "termEn": "songbook",
+      "official": "recueil de cantiques",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/1200275422"],
+      "confidence": "medium",
+      "notes": "Confirmed as a generic category label via a WOL index page (\"Recueils de cantiques\"). Not a Lexique entry. The current specific songbook title in use is \"Chantons joyeusement pour Jéhovah\"; older editions include \"Louons Jéhovah par nos chants\" and \"Chantons à Jéhovah\"."
+    },
+    {
+      "termEn": "convention",
+      "official": "assemblée régionale / assemblée internationale",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "IMPORTANT: French has no standalone word for \"convention\" in this sense - jw.org always uses \"assemblée\" plus a qualifier. Per the Lexique: \"assemblée régionale\" = \"Rassemblement annuel de trois jours qui réunit plusieurs assemblées locales d'une région donnée\"; \"assemblée internationale\" = \"Rassemblement de trois jours ... organisé ... tous les ans\" (larger/international scope). Do not flag a translation using \"assemblée\" instead of a literal \"convention\" as wrong."
+    },
+    {
+      "termEn": "assembly",
+      "official": "assemblée de circonscription",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Per the Lexique: \"Rassemblement de plusieurs assemblées locales de Témoins de Jéhovah sur une journée, deux fois par an\" - matches the seed's description of a gathering smaller than a convention. See the \"convention\" entry for the broader \"assemblée\" false-friend note, and the \"congregation\" entry for the unrelated sense of bare \"assemblée\" meaning congregation."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "école théocratique",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/201977406"],
+      "confidence": "low",
+      "notes": "Only found attested on a 1978-era WOL article about the discontinued \"Theocratic Ministry School\" (part of the old midweek meeting structure eliminated in the 2016 meeting restructuring). No current jw.org reference found. Not in the Lexique. If the app text refers to a still-active program (e.g. a school held in connection with assemblies/conventions), the current official French name could differ - treat this rendering with caution and verify against actual current app context before using it as a check."
+    },
+    {
+      "termEn": "sign language",
+      "official": "langue des signes",
+      "sourceUrls": ["https://www.jw.org/en/library/jw-meeting-workbook/"],
+      "confidence": "medium",
+      "notes": "Generic compound term, well established across jw.org's multilingual infrastructure (e.g. French Sign Language content is labelled \"langue des signes française\", locale codes such as sgn-CD/lsf). Not a dedicated Lexique entry and no single definitional quote was found, hence medium rather than high confidence."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Cahier pour la réunion Vie chrétienne et ministère",
+      "sourceUrls": ["https://www.jw.org/en/library/jw-meeting-workbook/"],
+      "confidence": "high",
+      "notes": "Full official title. Commonly shortened in monthly issue titles to \"Cahier Vie et ministère\" (e.g. \"Cahier Vie et ministère | Novembre-décembre 2025\") - either form should be acceptable in-app."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "texte de l'année",
+      "sourceUrls": ["https://wol.jw.org/fr/wol/d/r30/lp-f/1200276311"],
+      "confidence": "high",
+      "notes": "Confirmed via a WOL index heading (\"Texte de l'année\") plus a concrete example - the 2025 yeartext was rendered as \"Rendez à Jéhovah la gloire qui revient à son nom\" (Psaume 96:8)."
+    },
+    {
+      "termEn": "branch office",
+      "official": "filiale",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Lexique entry \"filiale, ou siège national\": \"Le centre administratif d'un comité de filiale utilisé pour superviser les activités religieuses des Témoins de Jéhovah dans un ou plusieurs pays.\" The informal synonym \"Béthel\" is also common in congregation-facing content."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Collège central des Témoins de Jéhovah",
+      "sourceUrls": [
+        "https://www.jw.org/fr/infos-pour-representants-de-l-etat/lexique/"
+      ],
+      "confidence": "high",
+      "notes": "Lexique: \"Petit groupe d'anciens choisis pour prendre soin des besoins spirituels des Témoins de Jéhovah du monde entier.\" Commonly shortened to \"Collège central\" in body text."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/hu.json
+++ b/scripts/i18n-quality/glossaries/hu.json
@@ -1,0 +1,266 @@
+{
+  "_comment": "Grounded JW terminology for hu, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "hu",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Jehova Tanúi",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide (\"Kifejezések, melyeket Jehova Tanúi használnak\", found via the English guide's hreflang=\"hu\" link): \"Olyan keresztények, akik Jehova Istent imádják, és az idejük egy részében bibliai oktatómunkát végeznek.\""
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Jehova Tanúi királyságterme",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide gives the full media-facing form \"Jehova Tanúi királyságterme\" (\"Imádati hely, melyet egy vagy több gyülekezet használ\"); everyday/congregation-facing content consistently shortens this to just \"királyságterem\"."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "körzetfelvigyázó",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Egy tapasztalt vén, aki a fiókhivatal felvigyázása alatt szolgál ..., és rendszeresen, általában évente kétszer, meglátogatja a körzetéhez tartozó gyülekezeteket. ... Ez az elnevezés nem rangot jelöl.\""
+    },
+    {
+      "termEn": "congregation",
+      "official": "gyülekezet",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Used consistently as the base term throughout the terminology guide (\"Jehova Tanúinak egy szervezett csoportja\") and every other jw.org page checked."
+    },
+    {
+      "termEn": "elder",
+      "official": "vén",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Jehova Tanúi közül egy olyan férfi, aki érett, és azzal a feladattal lett megbízva, hogy tanítsa a gyülekezetet, és pásztorkodjon felette.\" \"Felvigyázó\" (overseer) is used interchangeably with \"vén\" on the same page."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "a vének testületének koordinátora",
+      "sourceUrls": [
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1200271868",
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1102014935"
+      ],
+      "confidence": "medium",
+      "notes": "Not covered by the terminology guide (an internal congregation role, not explained to media). This role/title has been restructured in recent years: current Watchtower Online Library content describes \"a vének testületének koordinátora\" (coordinator of the body of elders) as the one who now chairs meetings of the body of elders, alongside other assigned elders (secretary, service overseer, Watchtower study conductor, life-and-ministry-meeting overseer). Could not find the older literal \"elnöklő felvigyázó\" (presiding overseer) still in current use on jw.org - if the app text predates the restructuring, a verbatim \"elnöklő felvigyázó\" may still appear in older strings. Verify against actual app context before treating a mismatch here as an error."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "kisegítőszolga",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Komoly gondolkodású, Jehova Tanújaként megkeresztelt férfi, aki támogatja a vének munkáját.\""
+    },
+    {
+      "termEn": "pioneer",
+      "official": "úttörő",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Megkeresztelt Tanú, aki vállalja, hogy egy meghatározott óraszámot tölt el a nyilvános szolgálatban.\" Guide also distinguishes \"általános úttörő\" (regular pioneer) and \"kisegítő úttörő\" (auxiliary pioneer)."
+    },
+    {
+      "termEn": "field service",
+      "official": "szántóföldi szolgálat",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Jehova Tanúi nyilvános szolgálata, mely során Jézus példáját követve megosztják a 'királyságról szóló jó hírt' az emberekkel.\""
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Krisztus halálának emlékünnepe",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Évenkénti megemlékezés Jézus Krisztus haláláról. Úgy is történik rá utalás, mint az Úr vacsorája, utolsó vacsora, emlékünnep vagy Jézus halálának emlékünnepe.\" Congregation-facing content commonly shortens this to just \"emlékünnep\"."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "gyülekezeti bibliatanulmányozás",
+      "sourceUrls": ["https://wol.jw.org/hu/wol/d/r17/lp-h/1200273746"],
+      "confidence": "medium",
+      "notes": "Not covered by the terminology guide. A Watchtower Online Library meetings-index page lists it as \"gyülekezeti bibliatanulmányozás (korábban gyülekezeti könyvtanulmányozás)\" - i.e. formerly called \"congregation book study\". Attested but not independently cross-checked against a second page."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "hét közbeni összejövetel",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/",
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1200273746"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide: \"Hetente, általában hétköznap este megtartott gyülekezeti összejövetel. A Keresztényi életünk és szolgálatunk elnevezésű programnak ... az a célja, hogy segítsen a Tanúknak Isten még jobb szolgáivá válni.\" Confirmed independently by a WOL meetings index, which also gives the fuller current label \"az életünk és szolgálatunk összejövetel\"."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "nyilvános összejövetel",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/",
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1200273746"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide: \"Hetente, általában hétvégén megtartott gyülekezeti összejövetel, mely során a hallgatóság egy ... 30 perces bibliai témájú előadást hallgathat meg ... Ezt követően egy egyórás program következik, melynek keretében az Őrtorony ... egyik cikke kerül megbeszélésre.\" A WOL meetings index instead labels the same meeting \"hétvégi összejövetel\" (literally \"weekend meeting\") - treat both as acceptable, and check app context for which register it uses."
+    },
+    {
+      "termEn": "public talk",
+      "official": "nyilvános előadás",
+      "sourceUrls": ["https://wol.jw.org/hu/wol/d/r17/lp-h/1200274680"],
+      "confidence": "high",
+      "notes": "Confirmed via a dedicated Watchtower Online Library index page titled \"Nyilvános előadások\" (plural), covering talk outlines/titles used from 1945-2023. Not a separate entry in the terminology guide, which folds it into the \"nyilvános összejövetel\" definition instead."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Őrtorony-tanulmányozás",
+      "sourceUrls": [
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1200273746",
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "WOL meetings index gives \"Őrtorony-tanulmányozás\" as the meeting-part name. The terminology guide describes the same segment without using this exact compound, referring instead to \"az Őrtorony tanulmányozásra szánt kiadásának\" (\"the Watchtower's study edition\") - the magazine issue used for it. See also \"The Watchtower\" entry."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "Az Őrtorony hirdeti Jehova királyságát",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title per the terminology guide. Consistently shortened to just \"Őrtorony\" in body text and issue titles (e.g. \"Őrtorony (tanulmányozásra szánt kiadás)\")."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Ébredjetek!",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed verbatim, including the exclamation mark, on the terminology guide (\"Egy folyóirat, melyet Jehova Tanúi adnak ki\")."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Szentírás – Új világ fordítás",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide: \"A Jehova Tanúi által fordított és közreadott\" Bible translation. Often shortened to \"Új világ fordítás\" in body text."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "App/proper-noun name is kept untranslated in Hungarian jw.org content (appears as \"JW Library®\" in the guide's footer links), consistent with the seed's instruction not to translate it."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Domain/proper noun kept as-is; the Hungarian site's own page header reads \"JW.ORG / JEHOVA TANÚI HIVATALOS HONLAPJA\" (\"jw.org / Jehovah's Witnesses' official website\"), matching the app's in-context phrase \"the official website of jw.org\"."
+    },
+    {
+      "termEn": "songbook",
+      "official": "énekeskönyv",
+      "sourceUrls": ["https://wol.jw.org/hu/wol/d/r17/lp-h/2010925"],
+      "confidence": "medium",
+      "notes": "Generic category term (\"Jehova Tanúi énekeskönyve\"), not a terminology-guide entry. The current specific songbook is titled \"Énekeljünk Jehovának!\" (\"Sing to Jehovah\", 2009/2016), superseding the older \"Énekeljetek dicséreteket Jehovának\"."
+    },
+    {
+      "termEn": "convention",
+      "official": "kongresszus",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "Generic entry \"kongresszus\" points to two current sub-types: \"regionális kongresszus\" (regional convention, 3 days/year, for congregations in a given area) and \"nemzetközi kongresszus\" (international convention, 3 days, delegates from multiple countries). Either qualified form may appear depending on scope; see \"assembly\" for the smaller one-day gathering."
+    },
+    {
+      "termEn": "assembly",
+      "official": "körzetkongresszus",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Jehova Tanúi több gyülekezetének egynapos összejövetele, melyet évente kétszer tartanak\" - i.e. the circuit assembly, matching the seed's description of a gathering smaller than a convention. Literally \"circuit convention\" - Hungarian uses the same base word \"kongresszus\" qualified differently rather than a distinct word for \"assembly\"; do not flag this as a mistranslation of \"convention\"."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "teokratikus iskola",
+      "sourceUrls": [
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/2012686",
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1102001051"
+      ],
+      "confidence": "low",
+      "notes": "Ambiguous/likely dated. \"Teokratikus szolgálati iskola\" (Theocratic Ministry School) was a specific midweek-meeting program discontinued in the 2009 meeting restructuring; a 2012 Watchtower article titled \"Teokratikus iskolák\" (\"Theocratic Schools\", plural) uses the generic phrase more broadly. No current jw.org reference names a single program by this exact generic label alongside assemblies/conventions - if the app text refers to a specific still-active program (e.g. Kingdom Ministry School, Pioneer Service School, Gilead), the correct Hungarian name would differ (e.g. \"Gileád-iskola\" per the terminology guide). Verify against actual app context before relying on this rendering."
+    },
+    {
+      "termEn": "sign language",
+      "official": "jelnyelv",
+      "sourceUrls": [
+        "https://www.jw.org/hu/konyvtar/folyoiratok/g200711/Tartalomjegyz%C3%A9k/"
+      ],
+      "confidence": "medium",
+      "notes": "Generic compound term, well established across jw.org's multilingual infrastructure (Hungarian Sign Language content and congregations are branded \"Magyar jelnyelv\", locale code hsh/HDF). Not a terminology-guide entry and no single definitional quote was found, hence medium rather than high confidence."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Keresztényi Életünk és Szolgálatunk – Munkafüzet",
+      "sourceUrls": [
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/202025160",
+        "https://wol.jw.org/hu/wol/d/r17/lp-h/1200273746"
+      ],
+      "confidence": "high",
+      "notes": "Full official title, confirmed consistently across many dated Watchtower Online Library issue pages (e.g. \"Keresztényi Életünk és Szolgálatunk – Munkafüzet, 2025. május–június\")."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "éviszöveg",
+      "sourceUrls": ["https://wol.jw.org/hu/wol/d/r17/lp-h/1200276311"],
+      "confidence": "high",
+      "notes": "Confirmed via a Watchtower Online Library index page titled \"Éviszövegek\" (plural), a chronological index of annual scriptural themes from 1915-2025. Not a terminology-guide entry."
+    },
+    {
+      "termEn": "branch office",
+      "official": "fiókhivatal",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Helyi adminisztrációs központ, ahonnan a fiókbizottság felügyeli és támogatja Jehova Tanúi egy vagy több országban folyó vallási tevékenységeit.\""
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Jehova Tanúi vezetőtestülete",
+      "sourceUrls": [
+        "https://www.jw.org/hu/hivatalos-tajekoztatas/kifejezesek-jehova-tanui-hasznalnak/"
+      ],
+      "confidence": "high",
+      "notes": "\"Vének egy kisebb csoportja, akik segítenek a világszerte élő Tanúknak, hogy jó kapcsolatot ápoljanak Istennel. A rövid elnevezése 'vezetőtestület'.\""
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/it.json
+++ b/scripts/i18n-quality/glossaries/it.json
@@ -1,0 +1,222 @@
+{
+  "_comment": "Grounded JW terminology for it, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "it",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Testimoni di Geova",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario defines it as \"gruppo religioso cristiano i cui aderenti adorano Geova Dio...\". The guide asks that the full name \"Testimoni di Geova\" be used on first occurrence; \"Testimoni\" alone is an acceptable shortened alternative. Forms like \"geovisti\"/\"geoviti\" are explicitly flagged as incorrect."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Sala del Regno",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Official/media-facing glossary gives the full form \"Sala del Regno dei Testimoni di Geova\", shortened in everyday use to \"Sala del Regno\". The guide explicitly asks that the term \"chiesa\" (church) not be used for it."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "sorvegliante di circoscrizione",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"anziano di esperienza che, sotto la guida della filiale, visita... ogni congregazione all'interno di una circoscrizione, di solito due volte l'anno.\" Not used as an honorific title."
+    },
+    {
+      "termEn": "congregation",
+      "official": "congregazione",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"gruppo organizzato di Testimoni che si riunisce regolarmente per il culto.\""
+    },
+    {
+      "termEn": "elder",
+      "official": "anziano",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"Testimone di sesso maschile, spiritualmente maturo, che viene incaricato di insegnare...\". Not capitalized, not an honorific."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "coordinatore del corpo degli anziani",
+      "sourceUrls": ["https://wol.jw.org/it/wol/d/r6/lp-i/1200276968"],
+      "confidence": "high",
+      "notes": "IMPORTANT terminology shift: the role formerly called \"sorvegliante presiedente\"/\"sorvegliante che presiede\" (presiding overseer) was renamed \"coordinatore del corpo degli anziani\" (coordinator of the body of elders) in the 2023 restructuring, per the dedicated WOL topic page, which explicitly cross-references the old title. The jw.org institutional glossary itself does not carry an entry for this role (it's congregation-internal, not media-facing), so this is grounded on WOL rather than the Glossario page. A translation still using \"sorvegliante presiedente\" would be stale."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "servitore di ministero",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"Testimone di sesso maschile, spiritualmente maturo, che viene incaricato di aiutare gli anziani a prendersi cura della congregazione.\" Not an honorific title."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "pioniere",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario covers \"pioniere regolare\" (regular pioneer, 600 h/year) and \"pioniere ausiliario\" (auxiliary pioneer, 15-30 h/month). Not an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "ministero di campo",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"ministero pubblico svolto dai Testimoni in ubbidienza al comando di Gesù...\". The same page cross-references \"predicazione\" (preaching) to this entry, so \"predicazione\" is used interchangeably in less formal contexts."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Commemorazione della morte di Cristo",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario gives the full form and notes it is also called \"Cena del Signore\", \"Pasto Serale del Signore\", \"Ultima Cena\", or simply \"Commemorazione\" / \"Commemorazione della morte di Gesù\". App-facing UI would most likely use the short form \"Commemorazione\"."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Studio biblico di congregazione",
+      "sourceUrls": ["https://wol.jw.org/it/wol/d/r6/lp-i/1200276966"],
+      "confidence": "high",
+      "notes": "Confirmed via a dedicated WOL topic page (heading and index both use this exact term). The same topic page notes this activity previously had other names (\"Studio di libro di congregazione\", etc.) before reaching its current form. Not covered on the jw.org institutional Glossario page."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "adunanza infrasettimanale",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"riunione, o adunanza, di solito tenuta in una sera infrasettimanale\" - the meeting whose program is \"Vita cristiana e ministero\"."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "adunanza pubblica",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"riunione, o adunanza, di solito tenuta nel fine settimana\", consisting of a public talk followed by the Watchtower Study."
+    },
+    {
+      "termEn": "public talk",
+      "official": "discorso pubblico",
+      "sourceUrls": [
+        "https://wol.jw.org/it/wol/d/r6/lp-i/1200274680",
+        "https://wol.jw.org/it/wol/d/r6/lp-i/1102001061"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via WOL topic index \"Discorsi pubblici\" and the article \"Come preparare un discorso pubblico\". The jw.org Glossario page describes the same 30-45 minute Bible talk under \"adunanza pubblica\" but without using this exact two-word phrase as a standalone heading."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "studio della Torre di Guardia",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario (under \"La Torre di Guardia\" entry): \"L'edizione per lo studio della Torre di Guardia... viene esaminata ogni settimana dalle congregazioni di tutto il mondo durante una trattazione con domande e risposte.\""
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "La Torre di Guardia",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario gives the full historical title \"La Torre di Guardia annunciante il Regno di Geova\", commonly shortened to \"La Torre di Guardia\". Published continuously since 1879."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Svegliatevi!",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: current name adopted from the 22 August 1946 issue; earlier names were \"L'Età d'Oro\" (from 1919) and \"Consolazione\" (from 1937). Exclamation mark is part of the proper name."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Traduzione del Nuovo Mondo delle Sacre Scritture",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario gives the full title and notes it is also called simply \"Traduzione del Nuovo Mondo\"."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "App/proper-noun name is not translated; used verbatim (with ® mark) in the Italian jw.org site navigation, matching seed context that this should not be translated."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Domain name is never translated. The Italian site's own footer renders it \"JW.ORG® / SITO UFFICIALE DEI TESTIMONI DI GEOVA\" (official website of Jehovah's Witnesses), matching the app's in-app phrasing \"the official website of jw.org\"."
+    },
+    {
+      "termEn": "songbook",
+      "official": "libretto dei cantici",
+      "sourceUrls": [
+        "https://wol.jw.org/it/wol/d/r6/lp-i/1966365",
+        "https://wol.jw.org/it/wol/d/r6/lp-i/1200275422"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via WOL announcement \"Nuovo libretto dei cantici!\" and the WOL topic index \"Libri dei cantici\". The current official songbook itself is also referred to by title (\"Cantiamo di cuore a Geova\" / \"Sing Out Joyfully to Jehovah\"), but \"libretto dei cantici\" is the generic term matching the seed's generic usage."
+    },
+    {
+      "termEn": "convention",
+      "official": "congresso",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario distinguishes \"congresso di zona\" (regional/zone convention, 3 days, yearly) and \"congresso internazionale\" (international convention, 3 days) from the shorter \"assemblea\" (see separate entry). \"Congresso\" alone redirects to these two entries."
+    },
+    {
+      "termEn": "assembly",
+      "official": "assemblea",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"assemblea\" redirects to \"assemblea di circoscrizione\" - a one-day gathering of several congregations held twice a year, smaller than a \"congresso\" (convention), exactly matching the seed's contrast between the two terms."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "scuola teocratica",
+      "sourceUrls": ["https://wol.jw.org/it/wol/d/r6/lp-i/1200277115"],
+      "confidence": "medium",
+      "notes": "\"Scuole teocratiche\" (plural) is a WOL topic-index umbrella covering Gilead (\"Scuola biblica di Galaad\"), the Pioneer Service School (\"Scuola del servizio di pioniere\"), and Kingdom Ministry School, among others. The original congregation-level \"Scuola di Ministero Teocratico\" (weekly Theocratic Ministry School) that ran 1943-2016 is now marked \"non più in vigore\" (discontinued) on WOL - it was folded into the \"Vita cristiana e ministero\" midweek meeting. Not on the jw.org Glossario page; medium confidence because it's unclear which specific program the app's seed context (\"training programs mentioned alongside assemblies/conventions\") refers to."
+    },
+    {
+      "termEn": "sign language",
+      "official": "lingua dei segni",
+      "sourceUrls": [
+        "https://www.jw.org/it/area-istituzionale/glossario/",
+        "https://www.jw.org/en/jehovahs-witnesses/activities/publishing/sign-language-translation/"
+      ],
+      "confidence": "high",
+      "notes": "The Italian jw.org site's own language picker uses \"Visualizza solo le lingue dei segni\" (Show only sign languages). Plural \"lingue dei segni\" used when referring to multiple sign languages generally (the jw.org publishing page cites translation into \"oltre 90 lingue dei segni\"); singular \"lingua dei segni\" for one, e.g. LIS (Lingua dei Segni Italiana)."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Guida alle attività per l'adunanza Vita cristiana e ministero",
+      "sourceUrls": [
+        "https://www.jw.org/en/library/jw-meeting-workbook/",
+        "https://wol.jw.org/it/wol/d/r6/lp-i/202024400"
+      ],
+      "confidence": "high",
+      "notes": "Full title confirmed consistently across many bi-monthly WOL editions (2016-2024+). Note: a shorter variant \"Guida per l'adunanza Vita e ministero\" also appears in at least one jw.org library listing (July-August 2023 edition) - jw.org itself is not fully consistent between the long and short forms."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "Scrittura dell'anno",
+      "sourceUrls": ["https://wol.jw.org/it/wol/d/r6/lp-i/1200276311"],
+      "confidence": "medium",
+      "notes": "\"Scrittura dell'anno\" is the current WOL topic-index heading for the annual scriptural theme (confirmed for the 2025 text, Psalm 96:8, \"Date a Geova la gloria che spetta al suo nome\"). Older/historical jw.org material instead used \"testo dell'anno\" for the same concept - medium confidence because both forms appear depending on era, and neither appears on the institutional Glossario page."
+    },
+    {
+      "termEn": "branch office",
+      "official": "filiale",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario: \"centro amministrativo locale utilizzato da un Comitato di Filiale per gestire e monitorare le attività religiose... in uno o più paesi.\" The overseeing body of elders is the \"Comitato di Filiale\" (Branch Committee)."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Corpo Direttivo",
+      "sourceUrls": ["https://www.jw.org/it/area-istituzionale/glossario/"],
+      "confidence": "high",
+      "notes": "Glossario gives the full form \"Corpo Direttivo dei Testimoni di Geova\", \"spesso chiamato semplicemente ‘Corpo Direttivo’\" (often called simply \"Governing Body\"). Headquartered in Warwick, New York."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/ko.json
+++ b/scripts/i18n-quality/glossaries/ko.json
@@ -1,0 +1,267 @@
+{
+  "_comment": "Grounded JW terminology for ko, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "ko",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "여호와의 증인",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Formal name to use on first mention per jw.org's own style note; may be shortened to 증인 (\"Witness(es)\") thereafter."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "왕국회관",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Full official form is 여호와의 증인 왕국회관, commonly shortened to 왕국회관. jw.org's guide explicitly asks that '교회' (church) not be used for this."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "순회 감독자",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Per jw.org's style note, this is not used as an honorific title before a person's name."
+    },
+    {
+      "termEn": "congregation",
+      "official": "회중",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "elder",
+      "official": "장로",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Per jw.org's style note, this is not used as an honorific title before a person's name."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "Not listed as a distinct role in jw.org's current (2026) Korean terminology guide, which suggests this specific title is no longer maintained as separate organizational terminology (congregation-meeting chairmanship rotates among elders without a distinct external title today). A related but non-equivalent role, 장로의 회 조정자 (Coordinator of the Body of Elders), was found, but it denotes chairing the body of elders' own meetings, not congregation meetings generally, so it was not recorded as a mapping to avoid inventing one."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "봉사의 종",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Per jw.org's style note, this is not used as an honorific title before a person's name."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "파이오니아",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Transliteration used as-is (not translated). Regular pioneer = 정규 파이오니아; auxiliary pioneer = 보조 파이오니아."
+    },
+    {
+      "termEn": "field service",
+      "official": "야외 봉사",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Also referred to generally as 전도 (\"preaching\"); the guide cross-references the two entries."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "그리스도의 죽음의 기념식",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Also called 주의 만찬, 기념식, or 예수의 죽음의 기념식. The short form 기념식 is common in site navigation and general UI contexts."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "회중 성서 연구",
+      "sourceUrls": [
+        "https://wol.jw.org/ko/wol/d/r8/lp-ko/202023086",
+        "https://wol.jw.org/ko/wol/dt/r8/lp-ko/2023/12/20"
+      ],
+      "confidence": "high",
+      "notes": "The 30-minute Bible study segment of the midweek meeting. Long-attested and stable across weekly wol.jw.org meeting schedules, though it is not a headline entry in the general terminology guide."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "평일 집회",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Officially the '그리스도인 생활과 봉사 집회' (Christian Life and Ministry Meeting); 평일 집회 is jw.org's own descriptive label for it in the terminology guide."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "공개 집회",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Comprises the public talk (공개 강연) followed by the Watchtower Study (「파수대」 연구)."
+    },
+    {
+      "termEn": "public talk",
+      "official": "공개 강연",
+      "sourceUrls": ["https://wol.jw.org/ko/wol/d/r8/lp-ko/1200274680"],
+      "confidence": "high",
+      "notes": "Watchtower Publications Index entry (title matches verbatim). Older publications used 공개 집회/공개 연설, per the index's own cross-reference."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "「파수대」 연구",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "The weekly one-hour question-and-answer study of the study edition of The Watchtower."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "「파수대—여호와의 왕국 선포」",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to 「파수대」. Public edition = 배부용 「파수대」; study edition = 연구용 「파수대」."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "「깨어라!」",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Includes the exclamation mark, per jw.org's own styling."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "「신세계역 성경」",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to 「신세계역」."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW 라이브러리",
+      "sourceUrls": [
+        "https://www.jw.org/en/online-help/jw-library/",
+        "https://wol.jw.org/ko/wol/d/r8/lp-ko/1200277277"
+      ],
+      "confidence": "high",
+      "notes": "App name: the 'JW' brand element is kept untranslated; '라이브러리' is the Korean rendering of 'Library'. Do not alter the JW portion."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "JW.ORG",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "jw.org always renders its own name in caps as 'JW.ORG' (the domain itself is not translated), paired on-site with the descriptor 여호와의 증인 공식 웹사이트 (\"official website of Jehovah's Witnesses\")."
+    },
+    {
+      "termEn": "songbook",
+      "official": "노래책",
+      "sourceUrls": ["https://wol.jw.org/ko/wol/d/r8/lp-ko/1200275422"],
+      "confidence": "high",
+      "notes": "Watchtower Publications Index entry (title matches verbatim). The current songbook is titled 「여호와께 노래하라」 (Sing to Jehovah)."
+    },
+    {
+      "termEn": "convention",
+      "official": "대회",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Umbrella term covering 순회 대회 (circuit convention), 지역 대회 (regional convention), and 국제 대회 (international convention)."
+    },
+    {
+      "termEn": "assembly",
+      "official": "순회 대회",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "medium",
+      "notes": "Inferred: jw.org's current terminology guide has no term distinct from the 대회 family (no separate word for 'assembly' vs. 'convention'). 순회 대회, a one-day gathering held twice yearly, is the closest match to the app's description of a gathering smaller than a (multi-day, regional/international) convention. Cross-check against actual app usage/context before treating as authoritative."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "신권 학교",
+      "sourceUrls": [
+        "https://wol.jw.org/ko/wol/d/r8/lp-ko/201976404",
+        "https://www.jw.org/en/library/magazines/w20120915/theocratic-schools/"
+      ],
+      "confidence": "medium",
+      "notes": "신권 학교 is jw.org's general term for organizational training schools, but it is not a distinct entry in the current terminology guide, and its exact present-day association with assembly/convention programs (as the app's seed context implies) could not be independently confirmed on a live ko-language page."
+    },
+    {
+      "termEn": "sign language",
+      "official": "수어",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via the terminology guide page's own site navigation (language filter option '수어만 표시하기' = \"show sign language only\")."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "그리스도인 생활과 봉사—집회 교재",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/",
+        "https://wol.jw.org/ko/wol/d/r8/lp-ko/202021320"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to 집회 교재 in navigation/UI contexts (confirmed in the terminology guide page's own publications menu)."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "올해의 성구",
+      "sourceUrls": [
+        "https://wol.jw.org/ko/wol/d/r8/lp-ko/2018242",
+        "https://wol.jw.org/ko/wol/d/r8/lp-ko/2022240"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via multiple wol.jw.org articles labeling a given year's scriptural theme, e.g. \"2018년 올해의 성구\", \"2022년 올해의 성구\"."
+    },
+    {
+      "termEn": "branch office",
+      "official": "지부 사무실",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to 지부."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "중앙장로회",
+      "sourceUrls": [
+        "https://www.jw.org/ko/%EB%8C%80%EC%99%B8-%EC%86%8C%ED%86%B5-%EC%9E%90%EB%A3%8C/%EC%9A%A9%EC%96%B4-%EC%84%A4%EB%AA%85/"
+      ],
+      "confidence": "high",
+      "notes": "Full official form is 여호와의 증인 중앙장로회, commonly shortened to 중앙장로회."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/nl.json
+++ b/scripts/i18n-quality/glossaries/nl.json
@@ -1,0 +1,262 @@
+{
+  "_comment": "Grounded JW terminology for nl, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "nl",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Jehovah's Getuigen",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Style guide: use the full official name at first reference; acceptable shorter alternative is 'de Getuigen'. For an individual, 'een Getuige' or 'een van Jehovah's Getuigen' (not 'Jehovah's Getuige' or 'Jehovah Getuige')."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Koninkrijkszaal van Jehovah's Getuigen",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to 'Koninkrijkszaal'. Style guide explicitly recommends against using 'kerk' (church)."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "kringopziener",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "congregation",
+      "official": "gemeente",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "elder",
+      "official": "ouderling",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Not used as an honorific title; elders are not a paid/clergy class."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "coördinator van het lichaam van ouderlingen",
+      "sourceUrls": [
+        "https://wol.jw.org/nl/wol/d/r18/lp-o/1200276968",
+        "https://wol.jw.org/nl/wol/d/r18/lp-o/1200274607"
+      ],
+      "confidence": "medium",
+      "notes": "jw.org's own Watchtower Publications Index (wol.jw.org) marks 'Presiderend opziener' as an OLD term (formerly 'Gemeenteopziener', 'Gemeentedienaar', 'Dienstleider'; not in the current terminology guide). The current official term for this coordinating role is 'coördinator van het lichaam van ouderlingen'. If the app string means only 'whichever elder chairs a given meeting' (a rotating, weekly duty) rather than the standing coordinator role, the plain word used is simply 'voorzitter'."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "dienaar in de bediening",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Not used as an honorific title."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "pionier",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Often used as short for 'gewone pionier' (regular pioneer) or 'hulppionier' (auxiliary pioneer)."
+    },
+    {
+      "termEn": "field service",
+      "official": "velddienst",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Style guide cross-references 'prediking' (preaching) as a synonym redirecting to 'velddienst'."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Herdenking van de dood van Christus",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to 'Herdenking' (used as a nav label elsewhere on jw.org). Also historically called 'het Avondmaal des Heren', 'het Laatste Avondmaal', or 'het Avondmaal'."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Gemeentebijbelstudie",
+      "sourceUrls": ["https://wol.jw.org/nl/wol/d/r18/lp-o/1201038"],
+      "confidence": "high",
+      "notes": "Written as one word, lowercase, in the official 'Richtlijnen voor de leven-en-dienenvergadering' (Life and Ministry Meeting Guidelines) page. Not covered by the general-audience terminology guide."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "doordeweekse vergadering",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Style-guide (press) term for the meeting whose program is titled 'Leven en dienen als christenen'. Congregation-internal literature also calls it the 'leven-en-dienenvergadering' (Life and Ministry Meeting)."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "openbare vergadering",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Refers to the whole weekend meeting (public talk + Watchtower Study), as distinct from 'openbare lezing', which names only the public-talk portion."
+    },
+    {
+      "termEn": "public talk",
+      "official": "openbare lezing",
+      "sourceUrls": ["https://wol.jw.org/nl/wol/d/r18/lp-o/1200274680"],
+      "confidence": "high",
+      "notes": "jw.org's Watchtower Publications Index notes this part was formerly called 'openbare vergadering' in older publications; that name is now reserved for the weekend meeting as a whole."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Wachttoren-studie",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Appears inline within the style guide's 'openbare vergadering' entry rather than as its own headword; a one-hour question-and-answer discussion following the public talk."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "De Wachttoren",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Full title 'De Wachttoren — Aankondiger van Jehovah's Koninkrijk'; has a public edition and a study edition."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Ontwaakt!",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Proper noun, includes exclamation mark. Adopted this Dutch title in 1951 (previously 'Het Gouden Tijdperk', then 'Vertroosting')."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Nieuwewereldvertaling",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Full form 'Nieuwewereldvertaling van de Bijbel'; written as a single compound word per current style guide."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Proper noun / app name, not translated — confirmed as-is on the Dutch jw.org site."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Rendered 'JW.ORG' in logo/brand contexts (all caps) and lowercase 'jw.org' in running text. Site tagline: 'Officiële website van Jehovah's Getuigen'."
+    },
+    {
+      "termEn": "songbook",
+      "official": "Zing lofzangen voor Jehovah",
+      "sourceUrls": [
+        "https://wol.jw.org/nl/wol/d/r18/lp-o/1994322",
+        "https://wol.jw.org/nl/wol/d/r18/lp-o/1200275422"
+      ],
+      "confidence": "medium",
+      "notes": "This is the title of the current JW songbook ('Sing Praises to Jehovah'), which superseded 'Zing met vreugde voor Jehovah' (2016) and 'Zing voor Jehovah' (2009). If the app's 'songbook' string is a generic noun rather than this specific title, a generic word such as 'liederenbundel' may be what's used in-app — check context before flagging a mismatch."
+    },
+    {
+      "termEn": "convention",
+      "official": "congres",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Style guide's 'congres' entry redirects to the two specific types: 'internationaal congres' (international convention) and 'regionaal congres' (regional convention). 'regionaal congres' most closely matches the seed's 'regional convention' sense."
+    },
+    {
+      "termEn": "assembly",
+      "official": "kringvergadering",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "A one-day, twice-yearly circuit-level meeting — smaller than a 'congres' (convention), matching the seed's context."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "theocratische school",
+      "sourceUrls": ["https://wol.jw.org/nl/wol/d/r18/lp-o/1102001126"],
+      "confidence": "medium",
+      "notes": "Also 'theocratische bedieningsschool'. This matches the pre-2023 congregation meeting structure (a weekly training school discontinued in the current 'leven-en-dienenvergadering' format) and is documented only in older Watchtower Library material — not in the current terminology guide. Confirm whether the app's usage is historical/legacy content or refers to a different training program held at assemblies/conventions."
+    },
+    {
+      "termEn": "sign language",
+      "official": "gebarentaal",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Generic Dutch word, confirmed via jw.org's own language-selector UI ('Alleen gebarentalen' = sign languages only) rather than a glossary headword."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Werkboek voor vergaderingen",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Generic label used in jw.org's own Library navigation for this publication category (the Our Christian Life and Ministry Meeting Workbook)."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "jaartekst",
+      "sourceUrls": ["https://wol.jw.org/nl/wol/d/r18/lp-o/1200028490"],
+      "confidence": "high",
+      "notes": "Confirmed via the Watchtower Publications Index ('Jaarteksten', plural, as the index headword)."
+    },
+    {
+      "termEn": "branch office",
+      "official": "bijkantoor",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Besturende Lichaam",
+      "sourceUrls": [
+        "https://www.jw.org/nl/internationale-communicatie/stijlgids-en-begrippenlijst/"
+      ],
+      "confidence": "high",
+      "notes": "Full form 'Besturende Lichaam van Jehovah's Getuigen'; commonly shortened to 'Besturende Lichaam'."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/pt.json
+++ b/scripts/i18n-quality/glossaries/pt.json
@@ -1,0 +1,262 @@
+{
+  "_comment": "Grounded JW terminology for pt (Brazilian Portuguese), cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "pt",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Testemunhas de Jeová",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guia de estilo e terminologia (Brazilian pt, hreflang=\"pt\" - distinct from pt-pt for Portugal) gives the full official name; guide explicitly instructs using the complete name \"Testemunhas de Jeová\" and, for an individual, \"uma Testemunha de Jeová\"."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Salão do Reino das Testemunhas de Jeová",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide gives the full form and notes it is often shortened to \"Salão do Reino\"; explicitly says to avoid the term \"igreja\" (church)."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "superintendente de circuito",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Term is not used as an honorific title, per the guide."
+    },
+    {
+      "termEn": "congregation",
+      "official": "congregação",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "elder",
+      "official": "ancião",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide stresses elders are unpaid and the term is not used as an honorific title."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "coordenador do corpo de anciãos",
+      "sourceUrls": ["https://wol.jw.org/pt/wol/d/r5/lp-t/1200276968"],
+      "confidence": "high",
+      "notes": "\"Presiding overseer\" (superintendente presidente) is a discontinued role name; jw.org's current official designation is \"coordenador do corpo de anciãos\" (coordinator of the body of elders), confirmed verbatim in the WOL page title. Not present in the terminology guide itself, which only lists media-facing terms."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "servo ministerial",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Unpaid appointment supporting elders with non-pastoral duties; term not used as an honorific title."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "pioneiro",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide distinguishes \"pioneiro regular\" (regular pioneer, 600 h/year) and \"pioneiro auxiliar\" (auxiliary pioneer, 15-30 h/month); plain \"pioneiro\" is often used as shorthand for regular pioneer."
+    },
+    {
+      "termEn": "field service",
+      "official": "serviço de campo",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide cross-references this from \"pregação\" (preaching); \"serviço de campo\" is the headword definition."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Celebração da morte de Cristo",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "IMPORTANT for reviewers: Brazilian Portuguese does NOT use a literal cognate of \"Memorial\" as the primary official term - jw.org's own term is \"Celebração da morte de Cristo\", commonly shortened to just \"Celebração\" (also referenced as Ceia do Senhor / Santa Ceia / Última Ceia). A translation using a literal \"Memorial\" cognate should be flagged."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Estudo Bíblico de Congregação",
+      "sourceUrls": ["https://wol.jw.org/pt/wol/d/r5/lp-t/1200276966"],
+      "confidence": "high",
+      "notes": "Not in the media-facing terminology guide; confirmed verbatim as the WOL glossary entry title. Superseded former names include \"Estudo de Livro de Congregação\"."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "reunião do meio de semana",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide describes its three-part program \"Nossa Vida e Ministério Cristão\"."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "Reunião Pública",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's headword for the weekly meeting held generally on the weekend, consisting of the public talk plus the Watchtower Study."
+    },
+    {
+      "termEn": "public talk",
+      "official": "discurso público",
+      "sourceUrls": [
+        "https://wol.jw.org/pt/wol/d/r5/lp-t/1200274680",
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Not a standalone headword in the terminology guide (which describes it only as \"discurso bíblico preparado para o público em geral\" within the Reunião Pública entry), but \"discurso público\" (plural: discursos públicos) is confirmed as jw.org's own term via the WOL glossary page title."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Estudo de A Sentinela",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Described within the Reunião Pública entry as a one-hour Q&A consideration of a Watchtower study-edition article."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "A Sentinela",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title is \"A Sentinela Anunciando o Reino de Jeová\"; public and study editions both referred to simply as \"A Sentinela\"."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Despertai!",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide notes prior titles \"A Idade de Ouro\" (1919) and \"Consolação\" (1937) before \"Despertai!\" was adopted in 1946. Exclamation mark is part of the proper title, matching English \"Awake!\"."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Tradução do Novo Mundo da Bíblia Sagrada",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Often shortened to \"Tradução do Novo Mundo\"; an earlier edition was titled \"Tradução do Novo Mundo das Escrituras Sagradas\"."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "App/proper-noun name kept untranslated on the Brazilian Portuguese site (appears as \"JW Library®\" in the page footer), consistent with the seed context that the app name itself is not translated."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Site footer renders it \"JW.ORG® / SITE OFICIAL DAS TESTEMUNHAS DE JEOVÁ\", matching the app's in-context phrase \"the official website of jw.org\" -> \"o site oficial das Testemunhas de Jeová, jw.org\"."
+    },
+    {
+      "termEn": "songbook",
+      "official": "Cante de Coração para Jeová",
+      "sourceUrls": [
+        "https://www.jw.org/pt/biblioteca/musicas-canticos/cante-de-coracao/"
+      ],
+      "confidence": "high",
+      "notes": "Not in the terminology guide; this is the current official Brazilian Portuguese title of the JW songbook (announced 2016), confirmed via jw.org's own hreflang=\"pt\" alternate-language metadata and page title. European Portuguese (pt-pt) uses a different title, ‘Cantemos com Alegria’ a Jeová, and Mozambican Portuguese (pt-mz) uses yet another - do not conflate. Generic references to \"our songbook\" in the app likely don't need the full proper title, but translators should recognize this as the current work."
+    },
+    {
+      "termEn": "convention",
+      "official": "congresso",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide splits into \"congresso internacional\" (international convention, 3 days) and \"congresso regional\" (regional convention, 3 days) - both larger than an assembly."
+    },
+    {
+      "termEn": "assembly",
+      "official": "assembleia de circuito",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "One-day gathering held twice a year for several congregations of a circuit; smaller than a \"congresso\" (convention), matching the seed's context distinction."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "escola teocrática",
+      "sourceUrls": [
+        "https://www.jw.org/pt/noticias/por-regiao/mundial/Retorno-das-assembleias-de-circuito-e-escolas-teocr%C3%A1ticas-presenciais/"
+      ],
+      "confidence": "high",
+      "notes": "Not in the terminology guide. Confirmed via jw.org's own hreflang=\"pt\" alternate for the English news article \"In-Person Circuit Assemblies and Theocratic Schools Resume\", whose Brazilian Portuguese title is \"Retorno das assembleias de circuito e escolas teocráticas presenciais\" (plural: escolas teocráticas), matching the app's exact phrasing pattern (\"theocratic schools, assemblies, or conventions\"). This is a generic umbrella term covering various named schools (e.g. Escola de Serviço de Precursor, Escola para Anciãos de Congregação); the historic \"Escola do Ministério Teocrático\" midweek-meeting school of the same name has since been discontinued, so don't confuse the two."
+    },
+    {
+      "termEn": "sign language",
+      "official": "língua de sinais",
+      "sourceUrls": ["https://wol.jw.org/pt/wol/d/r5/lp-t/1200275321"],
+      "confidence": "high",
+      "notes": "Not in the terminology guide. For \"sign-language congregations\" specifically, jw.org materials use \"congregação em língua de sinais\"; Brazil's own sign language is also called \"Libras\" (Língua Brasileira de Sinais) in Brazil-specific contexts, but \"língua de sinais\" is the generic term used across jw.org."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Nossa Vida e Ministério Cristão — Apostila da Reunião",
+      "sourceUrls": ["https://www.jw.org/pt/biblioteca/jw-apostila-do-mes/"],
+      "confidence": "high",
+      "notes": "Not in the terminology guide; confirmed via jw.org's own hreflang=\"pt\" alternate-language metadata and page title for the \"Our Christian Life and Ministry—Meeting Workbook\" library page. Note the em dash and that other Portuguese variants differ: pt-pt uses \"Vida e Ministério Cristãos – Manual de Atividades\", pt-mz uses a similar \"Manual de Atividades\", and pt-ao uses \"Programa da Reunião\" - don't conflate these with the Brazilian title."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "texto do ano",
+      "sourceUrls": [
+        "https://wol.jw.org/pt/wol/d/r5/lp-t/1102022212",
+        "https://wol.jw.org/pt/wol/d/r5/lp-t/1200027067"
+      ],
+      "confidence": "high",
+      "notes": "Not in the terminology guide. Confirmed verbatim on WOL pages (singular \"Texto do ano\" and glossary index \"Textos do ano\", plural)."
+    },
+    {
+      "termEn": "branch office",
+      "official": "filial",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's related entry \"Comissão de Filial\" (Branch Committee) is the group of elders overseeing a branch; often colloquially called \"sede\" (headquarters) too, per the guide."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Corpo Governante das Testemunhas de Jeová",
+      "sourceUrls": [
+        "https://www.jw.org/pt/informacoes-autoridades-jornalistas/guia-de-terminologia/"
+      ],
+      "confidence": "high",
+      "notes": "Guide notes the shorter form \"Corpo Governante\" is generally used."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/ru.json
+++ b/scripts/i18n-quality/glossaries/ru.json
@@ -1,0 +1,274 @@
+{
+  "_comment": "Grounded JW terminology for ru, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "ru",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Свидетели Иеговы",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Verbatim from jw.org's official Russian terminology guide (hreflang=\"ru\" version of the global terminology guide). jw.org/ru itself is fully accessible (HTTP 200, real content, not blocked/geofenced from our fetch location), as is wol.jw.org/ru."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Зал Царства",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Full heading term is \"Зал Царства Свидетелей Иеговы\"; guide notes it is often shortened to just \"Зал Царства.\""
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "районный старейшина",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Literally \"district/circuit elder,\" not a cognate of \"overseer.\" Definition matches English \"circuit overseer\" exactly (experienced elder under branch direction who regularly visits congregations in his circuit). Reflects the broader shift away from \"надзиратель\" (overseer) wording toward \"старейшина\" (elder) wording for this role; older Russian JW literature may use \"окружной/разъездной надзиратель.\""
+    },
+    {
+      "termEn": "congregation",
+      "official": "собрание",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "elder",
+      "official": "старейшина",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "координатор совета старейшин",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200276968",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200276968",
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200274607"
+      ],
+      "confidence": "high",
+      "notes": "Confirms the 2023 congregation-role restructuring: English \"Presiding Overseer\" is now a discontinued role, replaced by \"Coordinator of the Body of Elders.\" The Russian WOL page at the same glossary ID (1200276968) is titled \"Координатор совета старейшин.\" The old term is preserved at https://wol.jw.org/ru/wol/d/r2/lp-u/1200274607, titled \"Председательствующий надзиратель (упразднено)\" — literally \"Presiding overseer (abolished/discontinued).\" Do not use \"председательствующий надзиратель\" in new translations; it is explicitly marked obsolete by jw.org itself."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "помощник собрания",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/",
+        "https://www.jw.org/ru/библиотека/брошюры/воля-иеговы/служебные-помощники/"
+      ],
+      "confidence": "high",
+      "notes": "IMPORTANT inconsistency on jw.org itself: the current, actively-maintained terminology guide (definition text matches the English \"ministerial servant\" entry almost word for word) uses \"помощник собрания\" (literally \"congregation helper/assistant\"), NOT the literal cognate \"служебный помощник.\" But older doctrinal content still online — e.g. the \"Organized to Do Jehovah's Will\" brochure page titled \"Для чего нужны служебные помощники?\" — uses \"служебный помощник\" exclusively (17 occurrences, zero of \"помощник собрания\"). Treat \"помощник собрания\" as the current standard for new/updated app strings; \"служебный помощник\" is a legacy variant still circulating on jw.org, not an error per se, but not the freshest official term."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "пионер",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": ""
+    },
+    {
+      "termEn": "field service",
+      "official": "проповедническое служение",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Guide's heading is \"проповедническое служение; проповедь\" — both \"the preaching ministry\" and simply \"preaching\" are used."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Ве́черя воспоминания смерти Христа",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "NOT a cognate of \"Memorial\" — literally \"the Evening Meal of the commemoration of Christ's death.\" jw.org's own definition lists several accepted shorter alternates: Ужин Господа (the Lord's Supper), Вечеря Господня (the Lord's Evening Meal), Вечеря воспоминания (the Evening Meal of remembrance), and simply Вечеря (\"the Evening Meal/Supper\"). This mirrors the English guide, which itself leads with \"Memorial of Christ's death\" and lists \"Lord's Evening Meal\" etc. as alternates rather than a single fixed term — so some variation across app strings is expected and acceptable, but a translation using an unrelated word (e.g. a generic \"memorial/monument\" noun, or a discontinued Christendom holiday term) would be wrong."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Изучение Библии в собрании",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200276966",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200276966"
+      ],
+      "confidence": "high",
+      "notes": "Not covered by the main terminology guide; grounded via wol.jw.org's glossary/index, matching the English \"Congregation Bible Study\" entry at the same content ID."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "встреча в будние дни",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Definition confirms this is the meeting built around \"Наша христианская жизнь и служение\" (Our Christian Life and Ministry)."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "встреча в выходные дни",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Definition describes both parts: a 30-minute public talk, then roughly an hour of Q&A discussion of a Watchtower study article."
+    },
+    {
+      "termEn": "public talk",
+      "official": "публичная речь",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200274680",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200274680"
+      ],
+      "confidence": "high",
+      "notes": "wol.jw.org index entry is titled \"Публичные речи\" (plural, \"Public Talks\", matching the English index page at the same ID) and itself notes the former name: \"(Прежнее название: Публичная встреча)\" — i.e. \"public talk\" was formerly called \"public meeting\" in English too."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "изучение «Сторожевой башни»",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "medium",
+      "notes": "Not a fixed named term on jw.org — no dedicated glossary entry was found. The official terminology guide describes the concept periphrastically inside the \"weekend meeting\" definition (\"часовое обсуждение статьи из журнала «Сторожевая башня»\" — an hour-long discussion of a Watchtower article), and wol.jw.org search snippets consistently render the shorthand as \"изучение Сторожевой башни\" (compositional, mirroring \"Изучение Библии в собрании\" for Congregation Bible Study). Reasonably confident but not verbatim-sourced the way the other high-confidence terms are."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "«Сторожевая башня»",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title is «Сторожевая башня возвещает Царство Иеговы» (\"The Watchtower Announcing Jehovah's Kingdom\"); guide confirms the short form is «Сторожевая башня»."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "«Пробудитесь!»",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Guide confirms publication history: launched 1919 as «Золотой век» (Golden Age), renamed in 1937 to what became «Пробудитесь!». Includes exclamation mark as part of the proper title, matching the app's English context note."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "«Библия. Перевод „Новый мир“»",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Full official name per the terminology guide."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": ["https://www.jw.org/ru/онлайн-справка/jw-library/"],
+      "confidence": "high",
+      "notes": "App name is not translated/transliterated — the Russian help page's own title and heading both read \"JW Library\" verbatim, consistent with the app's own context note that this is a proper noun."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": ["https://www.jw.org/ru/"],
+      "confidence": "high",
+      "notes": "Domain/brand name is kept unchanged. The Russian homepage's own <title> is \"Официальный сайт Свидетелей Иеговы: jw.org\" (\"The official website of Jehovah's Witnesses: jw.org\"), which matches the app's in-app phrasing pattern (\"the official website of jw.org\") almost exactly."
+    },
+    {
+      "termEn": "songbook",
+      "official": "песенник",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200277315",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200277315"
+      ],
+      "confidence": "high",
+      "notes": "Generic word for \"songbook\" is \"песенник\"; the current specific songbook in use is titled «Радостно пойте Иегове» (Sing Out Joyfully to Jehovah), confirmed at the same glossary ID as the English \"Sing Out Joyfully to Jehovah (Songbook)\" entry."
+    },
+    {
+      "termEn": "convention",
+      "official": "конгресс",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "\"Конгресс\" is the umbrella term the guide itself uses (entry reads \"конгресс — смотрите: [international convention, regional convention]\"), with subtypes \"международный конгресс\" (international convention, 3-day) and \"региональный конгресс\" (regional convention, annual 3-day). See also \"assembly\" below for the smaller circuit-level gathering."
+    },
+    {
+      "termEn": "assembly",
+      "official": "районный конгресс",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/",
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200271236"
+      ],
+      "confidence": "high",
+      "notes": "This is the one-day, twice-yearly \"circuit assembly\" — smaller than the multi-day conventions above, matching the app's context (\"a larger JW gathering, smaller than a convention\"). Terminology guide gives the singular \"районный конгресс\"; the wol.jw.org glossary index (same ID as English \"Circuit Assemblies\") uses the plural \"Районные конгрессы.\""
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "теократические школы",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200277115",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200277115"
+      ],
+      "confidence": "high",
+      "notes": "Current, actively-maintained glossary umbrella term (matches English \"Theocratic Schools\" at the same ID), covering things like the Pioneer Service School and Kingdom Ministry School. Note the older \"Theocratic Ministry School\" (a specific weekly congregation program, discontinued in 2016) is a distinct, now-defunct thing — don't confuse the two if reviewing older strings."
+    },
+    {
+      "termEn": "sign language",
+      "official": "жестовый язык",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200275321",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200275321"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed both via the glossary (matches English \"Sign Language (Deaf)\" at the same ID) and via jw.org's own language picker, which lists \"русский жестовый\" for Russian Sign Language."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "«Наша христианская жизнь и служение». Рабочая тетрадь",
+      "sourceUrls": [
+        "https://www.jw.org/ru/библиотека/свидетелей-иеговы-встреча-рабочая-тетрадь/"
+      ],
+      "confidence": "high",
+      "notes": "Full official title of the Life and Ministry Meeting Workbook; \"рабочая тетрадь\" = \"workbook.\" The underlying midweek-meeting program itself is also called «Наша христианская жизнь и служение» (see \"midweek meeting\")."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "годовой текст",
+      "sourceUrls": [
+        "https://wol.jw.org/ru/wol/d/r2/lp-u/1200276311",
+        "https://wol.jw.org/en/wol/d/r1/lp-e/1200276311"
+      ],
+      "confidence": "high",
+      "notes": "Matches English \"Yeartexts\" at the same glossary ID."
+    },
+    {
+      "termEn": "branch office",
+      "official": "филиал",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Guide defines \"комитет филиала\" (branch committee) as a related, separate entry — three-or-more elders who direct activity in a country/group of countries out of a given \"филиал\" (branch office)."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Руководящий совет Свидетелей Иеговы",
+      "sourceUrls": [
+        "https://www.jw.org/ru/информация-для-мирового-профессионального-сообщества/лексика-и-терминология-свидетелей-иеговы/"
+      ],
+      "confidence": "high",
+      "notes": "Guide confirms it is often shortened to just «Руководящий совет»."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/sl.json
+++ b/scripts/i18n-quality/glossaries/sl.json
@@ -1,0 +1,260 @@
+{
+  "_comment": "Grounded JW terminology for sl, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "sl",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Jehovove priče",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide (found via the English guide's hreflang=\"sl\" link): \"Jehovove priče so krščanska verska skupnost.\" Guide asks that the full name \"Jehovove priče\" be used on first mention; \"Priče\" may be used afterward."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "kraljestvena dvorana Jehovovih prič",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide gives the full media-facing form; notes it is often shortened to just \"kraljestvena dvorana\" or \"dvorana\". Guide explicitly asks not to use \"cerkev\" (church)."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "okrajni nadzornik",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide: experienced elder (with wife if married) who regularly visits each congregation in an \"okraj\" (circuit), usually twice a year. Guide notes the term is not used as an honorific title."
+    },
+    {
+      "termEn": "congregation",
+      "official": "občina",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide: \"organizirana skupina Jehovovih prič, ki se redno zbira k bogočastju.\""
+    },
+    {
+      "termEn": "elder",
+      "official": "starešina",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide notes the term is not used as an honorific title."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "koordinator starešinstva",
+      "sourceUrls": ["https://wol.jw.org/sl/wol/d/r64/lp-sv/1102014935"],
+      "confidence": "high",
+      "notes": "Worldwide, \"presiding overseer\" was renamed \"coordinator of the body of elders\" effective Jan 1, 2009 (a change well before 2023, but still the reason this role no longer appears under the old name). This Slovenian-language wol.jw.org page (\"Nadzorniki so postavljeni, da pasejo čredo\", found by reusing the numeric ID 1102014935 from the identical English WOL page \"Overseers to Shepherd the Flock\") states plainly: \"Koordinator starešinstva služi na sestankih starešin kot predsedujoči.\" (The coordinator of the eldership serves as chairman at elders' meetings.) Not present under either name in the general-audience terminology guide, which is scoped to media-facing terms."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "strežni služabnik",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide notes the term is not used as an honorific title."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "pionir",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Covers both \"redni pionir\" (regular pioneer, 600 hrs/yr) and \"pomožni pionir\" (auxiliary pioneer). Guide notes the term is not used as an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "oznanjevanje",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide's \"oznanjevanje\" entry mirrors the English guide's \"field service\" entry word-for-word, down to the same citation of Matthew 24:14 and 28:19. The more literal phrase \"terenska služba\" (\"shod za tersko službo\" = meeting for field service) is also used in congregation-organization material (e.g. wol.jw.org/sl/wol/d/r64/lp-sv/1102014935) for the specific activity/meeting, but \"oznanjevanje\" is the term the official public-facing guide uses."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "spominska slovesnost",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Full heading in the terminology guide is \"slovesnost v spomin na Kristusovo smrt\" (\"solemn observance in memory of Christ's death\"), which the guide says is also called \"Gospodova večerja\" (Lord's Evening Meal), \"zadnja večerja\" (Last Supper), or, in short, \"spominska slovesnost\" (the Memorial). It is a literal, transparent rendering - not a cognate of a discontinued Christian holiday and not an obsolete phrase; verified directly against the official page, per the special attention this term needs."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Občinsko preučevanje Biblije",
+      "sourceUrls": [
+        "https://www.jw.org/sl/knjiznica/jehovove-price-delovni-zvezek/januar-februar-2022-mwb/Razpored-za-shod-%C5%BDivljenje-in-oznanjevanje-za-24-30-januar-2022/"
+      ],
+      "confidence": "high",
+      "notes": "Not covered by the terminology guide; found as the actual meeting-part heading on an official jw.org \"Naše krščansko življenje in oznanjevanje\" (Our Christian Life and Ministry) workbook schedule page."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "shod med tednom",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide: weekly meeting held on a weeknight, program titled \"Naše krščansko življenje in oznanjevanje\" (Our Christian Life and Ministry)."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "javni shod",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "The English terminology guide's parallel heading is \"Public Meeting\", not \"weekend meeting\" - the Slovenian entry \"Javni shod\" (\"vsakotedenski shod, ki ga ima občina običajno ob koncu tedna\") is its exact, verified counterpart. Comprises the public talk plus the Watchtower Study."
+    },
+    {
+      "termEn": "public talk",
+      "official": "javni govor",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Embedded within the \"Javni shod\" (weekend/public meeting) entry: a 30-minute \"javni govor\" opens the meeting."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Preučevanje Stražnega stolpa",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "One-hour question-and-answer discussion of the study-edition Watchtower article, per the \"Javni shod\" entry."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "Stražni stolp",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Full title given by the guide is \"Stražni stolp oznanja Jehovovo kraljestvo\"; \"Stražni stolp\" is confirmed as the standard short form, published in Public and Study editions."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "Prebudite se!",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Includes the exclamation mark per the terminology guide, which also gives the magazine's history (previously \"Zlati vek\", then \"Tolažba\")."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Prevod novi svet",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Full title per the guide is \"Sveto pismo – prevod novi svet\"; \"Prevod novi svet\" is given explicitly as the shorter designation."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "App name kept untranslated on the Slovenian jw.org site (footer: \"JW Library®\"), consistent with the seed's do-not-translate instruction."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "JW.ORG",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Rendered as the brand \"JW.ORG\" throughout the Slovenian site, unchanged from English."
+    },
+    {
+      "termEn": "songbook",
+      "official": "Pojmo hvalnice Jehovu",
+      "sourceUrls": ["https://wol.jw.org/sl/wol/d/r64/lp-sv/1101984246"],
+      "confidence": "high",
+      "notes": "Not covered by the terminology guide; confirmed as the current Slovenian songbook's title (\"Seznam pesmi\" / song list page on wol.jw.org) - the Slovenian counterpart of \"Sing Out Joyfully to Jehovah\"."
+    },
+    {
+      "termEn": "convention",
+      "official": "zborovanje",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "General term covering both \"mednarodno zborovanje\" (international convention) and \"regionalno zborovanje\" (regional convention) per the terminology guide; both are multi-day (three-day) gatherings, distinct from the one-day \"okrajni zbor\" (circuit assembly, see \"assembly\")."
+    },
+    {
+      "termEn": "assembly",
+      "official": "okrajni zbor",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Matches the English guide's \"circuit assembly\": a one-day gathering of several congregations, held about twice a year - explicitly smaller than the multi-day \"zborovanje\" (convention)."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "Teokratična strežbena šola",
+      "sourceUrls": ["https://wol.jw.org/sl/wol/d/r64/lp-sv/1102001051"],
+      "confidence": "medium",
+      "notes": "This is the historical Slovenian name for the \"Theocratic Ministry School\" meeting part (discontinued worldwide in 2009, merged into other meeting parts); not covered by the current terminology guide, and a generic glossary entry for present-day specialized \"theocratic schools\" (e.g. Pioneer Service School, Kingdom Ministry School) could not be found with a Slovenian translation. Recorded as medium confidence since it's a verified official rendering but may be outdated depending on which \"theocratic school\" the app text refers to."
+    },
+    {
+      "termEn": "sign language",
+      "official": "znakovni jezik",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via the site's own language-selector UI text on the terminology guide page: \"Prikaži samo znakovne jezike\" (Show only sign languages)."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "delovni zvezek",
+      "sourceUrls": [
+        "https://www.jw.org/sl/knjiznica/jehovove-price-delovni-zvezek/januar-februar-2022-mwb/Razpored-za-shod-%C5%BDivljenje-in-oznanjevanje-za-24-30-januar-2022/"
+      ],
+      "confidence": "high",
+      "notes": "Full publication title is \"Naše krščansko življenje in oznanjevanje – delovni zvezek\" (Our Christian Life and Ministry - Meeting Workbook), confirmed from the URL/breadcrumb of the official jw.org workbook page."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "letni stavek",
+      "sourceUrls": ["https://wol.jw.org/sl/wol/d/r64/lp-sv/302016030"],
+      "confidence": "high",
+      "notes": "Not covered by the terminology guide; found by reusing the numeric ID 302016030 from the English WOL page \"2016 Yeartext\" - the Slovenian page's title is \"Letni stavek za 2016\"."
+    },
+    {
+      "termEn": "branch office",
+      "official": "podružnični urad",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide notes the shorter form \"podružnica\" is also used; the related oversight body is \"podružnični odbor\" (branch committee)."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Vodstveni organ Jehovovih prič",
+      "sourceUrls": [
+        "https://www.jw.org/sl/informacije-za-javne-uslu%C5%BEbence-in-medije/terminologija-jehovovih-pric/"
+      ],
+      "confidence": "high",
+      "notes": "Terminology guide gives the full form; commonly shortened to \"Vodstveni organ\"."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/ty.json
+++ b/scripts/i18n-quality/glossaries/ty.json
@@ -1,0 +1,244 @@
+{
+  "_comment": "Grounded JW terminology for ty, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "ty",
+  "_note": "jw.org's official Terminology Guide (https://www.jw.org/en/global-communications/terminology-guide/) has NO Tahitian (ty) hreflang alternate - checked its <head> directly via curl and Tahitian is absent from its ~90 hreflang entries. Tahitian is a lower-resource language on jw.org than languages grounded previously (fr, hu, it, ko, nl, pt, uk, ru); all terms below were instead grounded against jw.org's public Tahitian site (jw.org/ty/) and wol.jw.org's Tahitian edition (wol.jw.org/ty/wol/d/r154/lp-th/<id>, sharing numeric ids with the English edition at .../r1/lp-e/<id> for actual translated articles). Several internal jw.org 'topic index' pages that exist only in major languages (numeric ids in the 1200xxxxxx / 1001xxxxxx range covering presiding overseer, ministerial servant, pioneer, Congregation Bible Study, public talk, yeartext as index entries) returned HTTP 404 when the same ids were requested under /ty/ - confirming those specific granular role/topic pages are simply not published in Tahitian, rather than a lookup mistake.",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Ite no Iehova",
+      "sourceUrls": ["https://www.jw.org/ty/"],
+      "confidence": "high",
+      "notes": "Used throughout jw.org/ty/ (site title, nav, every page footer)."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Piha a te Basileia",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/uiraa-a-te-taata/piha-basileia-ite-no-iehova/",
+        "https://www.jw.org/ty/ite-no-iehova/putuputuraa/"
+      ],
+      "confidence": "high",
+      "notes": "FAQ page title is literally 'No te aha “Piha a te Basileia”?' (Why 'Kingdom Hall'?). piha = hall/room, Basileia = Kingdom (Greek loanword, capitalized)."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "tiaau haaati",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/uiraa-a-te-taata/amuiraa-faanahohia/"
+      ],
+      "confidence": "high",
+      "notes": "From the official 'How are congregations organized' FAQ: 'E tere atu te tahi mau matahiapo ratere, parauhia tiaau haaati na roto i te mau amuiraa' (Traveling elders, called circuit overseers, visit the congregations). tiaau = overseer, haaati = circuit."
+    },
+    {
+      "termEn": "congregation",
+      "official": "amuiraa",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/uiraa-a-te-taata/amuiraa-faanahohia/"
+      ],
+      "confidence": "high",
+      "notes": "Used consistently across jw.org/ty/ for 'congregation' (e.g. page title 'Nafea te mau amuiraa a te mau Ite no Iehova e faanahohia ˈi?')."
+    },
+    {
+      "termEn": "elder",
+      "official": "matahiapo",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/uiraa-a-te-taata/amuiraa-faanahohia/"
+      ],
+      "confidence": "high",
+      "notes": "'Na te hoê tino matahiapo e tiaau i te amuiraa' (A body of elders oversees the congregation) - tino matahiapo = body of elders, matahiapo = elder."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "Not found in Tahitian. IMPORTANT: jw.org's own English terminology for this role changed after the 2023 congregation restructuring - 'Presiding Overseer' is now marked '(Discontinued)' on wol.jw.org (id 1200274607) and the current English term is 'Coordinator of the Body of Elders' (id 1200276968). Both the old and new English index pages return HTTP 404 when requested under wol.jw.org/ty/ - this specific role terminology does not appear to be published on the public Tahitian site at all. A reviewer should treat any Tahitian app string for this role with caution and verify separately (e.g. via a current Tahitian congregation resource) rather than trusting a literal translation of either 'presiding overseer' or 'coordinator'."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "Not found. The generic verb/root 'tavini' (to serve/servant) is well attested in Tahitian JW content, but no dedicated compound term for this specific congregation role was located on jw.org/ty/ or wol.jw.org/ty/ after multiple searches; the English index page (wol id 1200273848) 404s under /ty/."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "Not found on jw.org/ty/ or wol.jw.org/ty/ despite multiple targeted searches. Do not guess - this may be a transliterated loanword (as in French 'pionnier') or a native compound; needs verification from a current Tahitian publication."
+    },
+    {
+      "termEn": "field service",
+      "official": "taviniraa",
+      "sourceUrls": [
+        "https://www.jw.org/ty/piahia/faaineineraa-putuputuraa-ite-no-iehova/tetepa-atopa-2026-mwb/Porotarama-Oraraa-e-taviniraa-Kerisetiano-o-te-7-13-no-Tetepa-2026/"
+      ],
+      "confidence": "medium",
+      "notes": "No single fixed noun phrase corresponding to the English idiom 'field service' was found. The live meeting-workbook program page (an actual official schedule, not a guess) uses 'taviniraa' (ministry/service) for the general concept - section heading 'A RAVE MAITE I TA OE TAVINIRAA' (Apply Yourself to the Ministry) - and 'pororaa' (preaching) for specific methods, e.g. 'PORORAA FAANAHO-ORE-HIA' (informal witnessing) and 'I TERA E TERA FARE' (house to house). A reviewer should expect the app's 'field service' strings to map to 'taviniraa' or 'pororaa' depending on context rather than one fixed compound."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Oroa haamanaˈoraa",
+      "sourceUrls": ["https://www.jw.org/ty/ite-no-iehova/oroa-haamanaoraa/"],
+      "confidence": "high",
+      "notes": "Full official form is 'Oroa haamanaˈoraa o te pohe o Iesu' (Memorial of Jesus' death) - confirmed verbatim in the page's <title>, <h1>, and og:title/og:description. oroa = observance/ceremony, haamanaˈoraa = remembrance/commemoration. Checked specifically per the task's standing note that 'Memorial' is a frequent mistranslation trap in other languages - this is a clear, unambiguous, dedicated official rendering, not a cognate or borrowed holiday term. Note: jw.org's Tahitian site renders the ʻeta (glottal stop) using the character U+02C8 (MODIFIER LETTER VERTICAL LINE, ˈ) rather than the more common ʻokina (ʻ/ʼ) - reproduced here exactly as published."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Haapiiraa Bibilia a te amuiraa",
+      "sourceUrls": [
+        "https://www.jw.org/ty/piahia/faaineineraa-putuputuraa-ite-no-iehova/tetepa-atopa-2026-mwb/Porotarama-Oraraa-e-taviniraa-Kerisetiano-o-te-7-13-no-Tetepa-2026/"
+      ],
+      "confidence": "high",
+      "notes": "Found verbatim as item 8 of an actual, current (Sept 2026) Tahitian midweek-meeting program: 'Haapiiraa Bibilia a te amuiraa (30 min.)'. Literally 'Bible study of the congregation'."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "Putuputuraa Oraraa e taviniraa Kerisetiano",
+      "sourceUrls": [
+        "https://www.jw.org/ty/piahia/faaineineraa-putuputuraa-ite-no-iehova/",
+        "https://www.jw.org/ty/ite-no-iehova/putuputuraa/"
+      ],
+      "confidence": "medium",
+      "notes": "jw.org does not use a literal 'midweek'/'weekend' label publicly (its general meetings page just says congregations meet twice a week). The formal name of this meeting itself, taken from the meeting-workbook title, is 'Putuputuraa Oraraa e taviniraa Kerisetiano' (Christian Life and Ministry Meeting) - this is what the app's 'midweek meeting' string most likely corresponds to, but it is not literally the word 'midweek'."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "No distinct official Tahitian name found for this meeting as a whole (jw.org/ty/ite-no-iehova/putuputuraa/ describes meetings generically, twice a week, without naming each one). Its components are separately attested: the talk portion likely corresponds to 'oreroraa parau' (see 'public talk') and the study portion to 'Te Pare Tiairaa (Neneiraa no te haapiiraa)' (see 'Watchtower Study'), but no combined official label was located."
+    },
+    {
+      "termEn": "public talk",
+      "official": "oreroraa parau",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/tairururaa-toru-mahana/"
+      ],
+      "confidence": "medium",
+      "notes": "'oreroraa parau' (discourse/talk) appears on the official 2026 convention page describing a program talk ('I roto i te oreroraa parau “Ua itehia anei ia outou te taˈoa rahi?”'). This is a generic word for 'talk/discourse' seen in a convention program, not confirmed as a fixed label specifically for the weekend meeting's opening talk - treat as a reasonable but unconfirmed candidate."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Te Pare Tiairaa (Neneiraa no te haapiiraa)",
+      "sourceUrls": ["https://www.jw.org/ty/piahia/vea/"],
+      "confidence": "high",
+      "notes": "'Neneiraa no te haapiiraa' = study edition, appended to the magazine name 'Te Pare Tiairaa' on the official magazines page."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "Te Pare Tiairaa",
+      "sourceUrls": ["https://www.jw.org/ty/piahia/vea/"],
+      "confidence": "high",
+      "notes": "Page title 'Te Pare Tiairaa e A ara mai na!' (The Watchtower and Awake!). Pare tiairaa ≈ 'watchtower/lookout post'."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "A ara mai na!",
+      "sourceUrls": ["https://www.jw.org/ty/piahia/vea/"],
+      "confidence": "high",
+      "notes": "Exclamation mark is part of the official title, matching the seed's note that it's a proper noun including the '!'."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "Te Bibilia, Huriraa o te ao apî",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/uiraa-a-te-taata/jw-bibilia-nwt/",
+        "https://www.jw.org/ty/piahia/bibilia/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed verbatim repeatedly (e.g. 'Ua faaohipa te mau Ite no Iehova e rave rahi huriraa a haapii ai i te Bibilia. E rave râ matou i Te Bibilia, Huriraa o te ao apî'). Often shortened to 'Huriraa o te ao apî' (Translation of the New World) in running text; abbreviation 'NWT' is also used as-is."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": ["https://www.jw.org/en/online-help/jw-library/"],
+      "confidence": "high",
+      "notes": "App/brand name is kept unchanged across all jw.org language editions, including Tahitian - consistent with the seed's note not to translate the app name. Could not find a Tahitian jw.org page mentioning it by name directly (the Tahitian site's app-related pages found during this run were about free Bible study offers, not the app), but jw.org's universal branding convention for this proper noun is well established."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "jw.org",
+      "sourceUrls": ["https://www.jw.org/ty/"],
+      "confidence": "high",
+      "notes": "Domain name / proper noun, never localized, as on every other language edition of the site."
+    },
+    {
+      "termEn": "songbook",
+      "official": "Himene ma te oaoa ia Iehova",
+      "sourceUrls": ["https://www.jw.org/ty/piahia/upaupa-himene/"],
+      "confidence": "high",
+      "notes": "Current official songbook title, equivalent to English 'Sing Out Joyfully to Jehovah!'. The general music/songs section is titled 'Upaupa no te haamoriraa Kerisetiano' (Music for Christian Worship); the previous songbook 'Himene ia Iehova' (Sing to Jehovah) is also listed as an older edition."
+    },
+    {
+      "termEn": "convention",
+      "official": "Tairururaa e toru mahana",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/tairururaa-toru-mahana/"
+      ],
+      "confidence": "high",
+      "notes": "Literally 'three-day convention', the current regional convention. Base word 'tairururaa' (large gathering/convention) is shared with 'assembly' below and disambiguated by a qualifier - see that entry for the smaller circuit assembly."
+    },
+    {
+      "termEn": "assembly",
+      "official": "tairururaa haaati",
+      "sourceUrls": ["https://wol.jw.org/ty/wol/d/r154/lp-th/402018287"],
+      "confidence": "high",
+      "notes": "Circuit assembly (smaller than the regional convention), confirmed verbatim in a Tahitian Watchtower article: 'I te mau tairururaa haaati, ua matau te hoê taeae...' (At circuit assemblies, a brother...). haaati = circuit."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "Not found on jw.org/ty/ or wol.jw.org/ty/. This may refer to a discontinued/renamed program (e.g. the former Theocratic Ministry School, folded into the current meeting structure after past restructurings) - do not guess a Tahitian rendering."
+    },
+    {
+      "termEn": "sign language",
+      "official": "reo aparaa rima",
+      "sourceUrls": [
+        "https://www.jw.org/ty/piahia/tapura-vairaa-papai/",
+        "https://www.jw.org/ty/piahia/upaupa-himene/"
+      ],
+      "confidence": "high",
+      "notes": "Used consistently and extensively across jw.org/ty/ language pickers, e.g. 'Reo aparaa rima Farani' (French Sign Language), 'Reo aparaa rima Beretane' (British Sign Language), etc. Literally 'hand-touching language'."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "Faaineineraa no te putuputuraa: Oraraa e taviniraa Kerisetiano",
+      "sourceUrls": [
+        "https://www.jw.org/ty/piahia/faaineineraa-putuputuraa-ite-no-iehova/"
+      ],
+      "confidence": "high",
+      "notes": "Official title, equivalent to English 'Our Christian Life and Ministry Meeting Workbook'. faaineineraa = preparation, putuputuraa = meeting."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "",
+      "sourceUrls": [],
+      "confidence": "low",
+      "notes": "Not found on jw.org/ty/ or wol.jw.org/ty/ despite targeted searches; the English wol.jw.org index page for 'Yeartexts' (id 1200276311) has no located Tahitian counterpart."
+    },
+    {
+      "termEn": "branch office",
+      "official": "Piha ohipa",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/piha-ohipa-e-mataitairaa/"
+      ],
+      "confidence": "high",
+      "notes": "Page title 'Piha ohipa e mataitairaa: Pu rahi a te mau Ite no Iehova e te mau piha ohipa na te ao nei' (Branch offices and visits: world headquarters and branch offices worldwide). The page itself notes branch offices are commonly called 'Betela' (Bethel) informally: 'parau-pinepine-hia Betela'."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Tino aratai",
+      "sourceUrls": [
+        "https://www.jw.org/ty/ite-no-iehova/uiraa-a-te-taata/tino-aratai/",
+        "https://www.jw.org/ty/piahia/faaineineraa-putuputuraa-ite-no-iehova/tetepa-atopa-2026-mwb/Porotarama-Oraraa-e-taviniraa-Kerisetiano-o-te-7-13-no-Tetepa-2026/"
+      ],
+      "confidence": "high",
+      "notes": "FAQ page title: 'Eaha te Tino aratai a te mau Ite no Iehova?' (What is the Governing Body of Jehovah's Witnesses?). Also confirmed in live use in an official 2026 meeting program referencing 'Video parau apî n° 6 a te Tino aratai 2024' (Governing Body Update video number 6, 2024). Literally 'leading/guiding body'."
+    }
+  ]
+}

--- a/scripts/i18n-quality/glossaries/uk.json
+++ b/scripts/i18n-quality/glossaries/uk.json
@@ -1,0 +1,264 @@
+{
+  "_comment": "Grounded JW terminology for uk, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "2026-09-10",
+  "_language": "uk",
+  "terms": [
+    {
+      "termEn": "Jehovah's Witnesses",
+      "official": "Свідки Єгови",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "First reference should use the full name «Свідки Єгови»; acceptable short forms are «Свідок»/«Свідки» per the guide's own note."
+    },
+    {
+      "termEn": "Kingdom Hall",
+      "official": "Зал Царства Свідків Єгови; Зал Царства",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "The guide explicitly says to avoid the word «церква» (church) for this."
+    },
+    {
+      "termEn": "circuit overseer",
+      "official": "районний наглядач",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "«район» = circuit (a group of congregations); not used as an honorific title per the guide."
+    },
+    {
+      "termEn": "congregation",
+      "official": "збір",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "«збір» is the formal glossary headword, but jw.org's own running text (including elsewhere on this same glossary page and in meeting-workbook articles) very commonly uses «громада» as a synonym for a local congregation. Both are legitimate; a review should not flag «громада» as wrong."
+    },
+    {
+      "termEn": "elder",
+      "official": "старійшина",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Not used as an honorific title/form of address per the guide."
+    },
+    {
+      "termEn": "presiding overseer",
+      "official": "координатор ради старійшин",
+      "sourceUrls": ["https://wol.jw.org/uk/wol/d/r15/lp-k/1102014935"],
+      "confidence": "high",
+      "notes": "IMPORTANT: this role was renamed org-wide in the 2023 congregation-role restructuring; \"presiding overseer\" no longer exists as a role in current English JW terminology either (replaced by \"coordinator of the body of elders\"). Not present in jw.org's official Terminology Guide (neither the EN nor UK version lists it), so grounded instead from an official Watchtower Online Library article (\"Наглядачі, призначені пасти отару\"), which quotes verbatim: «Координатор ради старійшин бере провід на зустрічах ради старійшин.» If the app still shows an older term like «головуючий наглядач», that is now outdated."
+    },
+    {
+      "termEn": "ministerial servant",
+      "official": "служитель збору",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Literally \"servant of the congregation\"; not used as an honorific title."
+    },
+    {
+      "termEn": "pioneer",
+      "official": "піонер",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Subtypes: «сталий піонер» (regular pioneer, 600 hrs/year) and «допоміжний піонер» (auxiliary pioneer, 15-30 hrs/month). Not an honorific title."
+    },
+    {
+      "termEn": "field service",
+      "official": "проповідницьке служіння; проповідування",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Both forms appear as one combined headword on the official glossary."
+    },
+    {
+      "termEn": "Memorial",
+      "official": "Спомин Христової смерті",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Short form used everywhere in running text (confirmed independently in a 2025 meeting-workbook article) is simply «Спомин». Also called «Господня вечеря» in the full definition. Flag any app string using a discontinued Christian-holiday word (e.g. anything resembling \"Пасха\"/\"Великдень\") or an invented cognate of \"memorial\" (e.g. \"меморіал\") as wrong — «меморіал» is NOT the term jw.org uses for this event."
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "official": "Вивчення Біблії у зборі",
+      "sourceUrls": [
+        "https://www.jw.org/uk/бібліотека/посібник-для-зібрання/березень-квітень-2025-mwb/Розклад-зібрання-Християнського-життя-і-служіння-на-7-13-квітня-2025-року/"
+      ],
+      "confidence": "high",
+      "notes": "Verified verbatim as agenda item \"8. Вивчення Біблії у зборі (30 хв)\" in a live meeting-workbook schedule page (raw HTML, not a search summary). Not covered by the general Terminology Guide."
+    },
+    {
+      "termEn": "midweek meeting",
+      "official": "зібрання серед тижня",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Officially named program is «Наше християнське життя і служіння» (Our Christian Life and Ministry)."
+    },
+    {
+      "termEn": "weekend meeting",
+      "official": "публічне зібрання",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "The glossary's «публічне зібрання» entry covers the whole weekend meeting (public talk + Watchtower Study), not just the talk portion."
+    },
+    {
+      "termEn": "public talk",
+      "official": "публічна промова",
+      "sourceUrls": ["https://wol.jw.org/uk/wol/d/r15/lp-k/1200274680"],
+      "confidence": "high",
+      "notes": "Not a separate headword in the Terminology Guide itself (which folds it into the «публічне зібрання» definition as a \"30-minute talk\"), but «Публічні промови» (plural) is the exact title of an official Watchtower Online Library section/category, confirming «публічна промова» as the standard singular term."
+    },
+    {
+      "termEn": "Watchtower Study",
+      "official": "Вивчення «Вартової башти»",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/",
+        "https://wol.jw.org/uk/wol/meetings/r15/lp-k/2024/22"
+      ],
+      "confidence": "high",
+      "notes": "Named as \"this part is called «вивченням «Вартової башти»»\" within the weekend-meeting definition, and independently confirmed as a schedule label on a WOL meetings page."
+    },
+    {
+      "termEn": "The Watchtower",
+      "official": "«Вартова башта»",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Full title: «Вартова башта оголошує Царство Єгови». Published since 1879; has Public and Study editions."
+    },
+    {
+      "termEn": "Awake!",
+      "official": "«Пробудись!»",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Includes the exclamation mark, per the glossary's own usage. Historical prior titles noted on the page: «Золотий вік» (1919), «Вістник Потіхи» (1937), current title since Aug 22, 1946."
+    },
+    {
+      "termEn": "New World Translation",
+      "official": "«Переклад нового світу»",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Full name: «Біблія. Переклад нового світу»."
+    },
+    {
+      "termEn": "JW Library",
+      "official": "JW Library",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed via the site's own footer navigation on the Ukrainian glossary page — the app name is kept in English/Latin script, not translated or transliterated."
+    },
+    {
+      "termEn": "jw.org",
+      "official": "JW.ORG",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Brand/logo form is all-caps «JW.ORG» (seen repeatedly in the page's own header/footer); in running prose the site refers to itself in lowercase as \"jw.org\", also untranslated/untransliterated."
+    },
+    {
+      "termEn": "songbook",
+      "official": "«Радісно співайте Єгові»",
+      "sourceUrls": [
+        "https://www.jw.org/uk/бібліотека/музика-пісні/радісно-співайте-єгові/"
+      ],
+      "confidence": "high",
+      "notes": "This is the title of the current official songbook (\"Sing Out Joyfully to Jehovah\"), found via the English songbook page's own hreflang=\"uk\" alternate-link metadata. If the app uses a generic word for \"songbook\" rather than this proper title, a close generic equivalent would be «збірник пісень», but jw.org itself names the actual book as above."
+    },
+    {
+      "termEn": "convention",
+      "official": "конгрес (регіональний конгрес / міжнародний конгрес)",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "medium",
+      "notes": "Ukrainian does not lexically split \"assembly\" vs \"convention\" the way the English glossary's headwords do; it uses one base word «конгрес» plus a qualifier for every size/level: «районний конгрес» (circuit assembly), «регіональний конгрес» (regional convention), «міжнародний конгрес» (international convention). Marked medium because mapping the app's generic seed term \"convention\" onto one exact Ukrainian string required interpretation across three related headwords rather than a single 1:1 match."
+    },
+    {
+      "termEn": "assembly",
+      "official": "районний конгрес",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Corresponds to the English glossary's \"circuit assembly\" (a one-day meeting held twice yearly) — the smaller gathering relative to \"convention\". Also relevant: «Зал конгресів (Свідків Єгови)» = Assembly Hall."
+    },
+    {
+      "termEn": "theocratic school",
+      "official": "Школа теократичного служіння",
+      "sourceUrls": [
+        "https://wol.jw.org/uk/wol/d/r15/lp-k/201998403",
+        "https://wol.jw.org/uk/wol/d/r15/lp-k/202002408"
+      ],
+      "confidence": "medium",
+      "notes": "This is a legacy/historical term (Theocratic Ministry School, running from 1943 until it was folded into the current \"Our Christian Life and Ministry\" meeting/school in the 2013 meeting-format reorganization). Not in the current Terminology Guide. If the app is describing current programs, this term should NOT appear as a live feature name — flag any current-tense usage as likely outdated; it's only valid in a historical context."
+    },
+    {
+      "termEn": "sign language",
+      "official": "жестова мова / жестові мови",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Confirmed from the site's own language-picker UI text on the Ukrainian glossary page itself: «Показати тільки жестові мови» (\"Show only sign languages\")."
+    },
+    {
+      "termEn": "meeting workbook",
+      "official": "«Наше християнське життя і служіння. Посібник для зібрання»",
+      "sourceUrls": ["https://www.jw.org/uk/бібліотека/посібник-для-зібрання/"],
+      "confidence": "high",
+      "notes": "Found via the English workbook index page's hreflang=\"uk\" alternate-link title metadata. Often just called «Посібник для зібрання» for short."
+    },
+    {
+      "termEn": "yeartext",
+      "official": "вірш на [рік] рік",
+      "sourceUrls": [
+        "https://www.jw.org/uk/бібліотека/журнали/вартова-башта-вивчення-січень-2026/Задовольняйте-свої-духовні-потреби/"
+      ],
+      "confidence": "high",
+      "notes": "Verified verbatim in the raw HTML of the January 2026 Watchtower Study article, which opens with the heading «ВІРШ НА 2026 РІК:» before quoting Matthew 5:3. NOT «текст року» — a plausible-looking calque that does not appear on jw.org; the actual official phrasing is «вірш на [рік] рік» (\"verse for the year [X]\")."
+    },
+    {
+      "termEn": "branch office",
+      "official": "філіал",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Full definition refers to it as a religious center from which the «комітет філіалу» (Branch Committee) supports and coordinates spiritual activity in one or more countries."
+    },
+    {
+      "termEn": "Governing Body",
+      "official": "Керівний орган Свідків Єгови",
+      "sourceUrls": [
+        "https://www.jw.org/uk/глобальні-комунікації/термінологічний-словник/"
+      ],
+      "confidence": "high",
+      "notes": "Commonly shortened to «Керівний орган», per the guide's own note."
+    }
+  ]
+}

--- a/scripts/i18n-quality/jw-terms-seed.json
+++ b/scripts/i18n-quality/jw-terms-seed.json
@@ -1,0 +1,97 @@
+{
+  "_comment": "Curated list of JW-organizational terms that actually appear in this app's content (grepped from src/i18n/en.json and docs/src/en/**), for grounding-agent.md to look up official per-language renderings on jw.org. Not every translated string touches these terms - most i18n keys are generic UI words (Cancel, Settings, Download) that never need terminology grounding. `sourceUrls` are intentionally empty here: the grounding agent finds and cites its own jw.org sources per language rather than being handed unverified links.",
+  "terms": [
+    { "termEn": "Jehovah's Witnesses", "context": "the organization's name" },
+    { "termEn": "Kingdom Hall", "context": "the local meeting place" },
+    {
+      "termEn": "circuit overseer",
+      "context": "a traveling minister who oversees a circuit of congregations"
+    },
+    {
+      "termEn": "congregation",
+      "context": "a local group of Jehovah's Witnesses"
+    },
+    { "termEn": "elder", "context": "a congregation overseer" },
+    {
+      "termEn": "presiding overseer",
+      "context": "the elder who chairs congregation meetings"
+    },
+    {
+      "termEn": "ministerial servant",
+      "context": "an appointed congregation helper"
+    },
+    { "termEn": "pioneer", "context": "a full-time volunteer minister" },
+    { "termEn": "field service", "context": "the ministry/preaching work" },
+    {
+      "termEn": "Memorial",
+      "context": "the annual commemoration of Christ's death"
+    },
+    {
+      "termEn": "Congregation Bible Study",
+      "context": "abbreviated CBS in the app"
+    },
+    {
+      "termEn": "midweek meeting",
+      "context": "one of the two weekly congregation meetings"
+    },
+    {
+      "termEn": "weekend meeting",
+      "context": "the other weekly congregation meeting"
+    },
+    {
+      "termEn": "public talk",
+      "context": "the weekend meeting's opening talk"
+    },
+    {
+      "termEn": "Watchtower Study",
+      "context": "a Bible study article discussed at meetings; abbreviated WT in the app"
+    },
+    {
+      "termEn": "The Watchtower",
+      "context": "the magazine, Public and Study editions"
+    },
+    {
+      "termEn": "Awake!",
+      "context": "a JW magazine title - proper noun, includes the exclamation mark"
+    },
+    {
+      "termEn": "New World Translation",
+      "context": "the Bible translation JWs use"
+    },
+    {
+      "termEn": "JW Library",
+      "context": "the official JW mobile app - proper noun, do not translate the app name itself"
+    },
+    {
+      "termEn": "jw.org",
+      "context": "the official website - referred to in-app as \"the official website of jw.org\""
+    },
+    { "termEn": "songbook", "context": "the JW songbook used at meetings" },
+    {
+      "termEn": "convention",
+      "context": "a larger JW gathering (circuit assembly / regional convention)"
+    },
+    {
+      "termEn": "assembly",
+      "context": "a larger JW gathering, smaller than a convention"
+    },
+    {
+      "termEn": "theocratic school",
+      "context": "training programs mentioned alongside assemblies/conventions"
+    },
+    {
+      "termEn": "sign language",
+      "context": "sign-language congregations/media"
+    },
+    {
+      "termEn": "meeting workbook",
+      "context": "the Our Christian Life and Ministry workbook"
+    },
+    { "termEn": "yeartext", "context": "the annual scriptural theme" },
+    {
+      "termEn": "branch office",
+      "context": "a regional JW administrative office"
+    },
+    { "termEn": "Governing Body", "context": "the organization's leading body" }
+  ]
+}

--- a/scripts/i18n-quality/merge-batches.mjs
+++ b/scripts/i18n-quality/merge-batches.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Merges per-batch review-agent output (proposed/<lang>/<contentType>-batch-N.json)
+ * into the single proposed/<lang>/<contentType>.json file
+ * validate-proposed-changes.mjs expects.
+ *
+ * Usage:
+ *   node scripts/i18n-quality/merge-batches.mjs --run-id <id> --language fr --content-type i18n
+ */
+import fsx from 'fs-extra';
+import { resolve } from 'node:path';
+
+const { pathExists, readdir, readJson, writeFile } = fsx;
+
+async function main() {
+  const { contentType, language, runId } = parseArgs(process.argv.slice(2));
+  if (!language || !contentType || !runId) {
+    console.error(
+      'Usage: node merge-batches.mjs --run-id <id> --language <code> --content-type <type>',
+    );
+    process.exit(1);
+  }
+
+  const proposedDir = resolve(
+    'reports/translation-quality',
+    runId,
+    'proposed',
+    language,
+  );
+  await fsx.ensureDir(proposedDir);
+
+  const batchPrefix = `${contentType}-batch-`;
+  const files = (await readdir(proposedDir))
+    .filter((f) => f.startsWith(batchPrefix) && f.endsWith('.json'))
+    .sort();
+
+  let merged = [];
+  for (const file of files) {
+    const batch = await readJson(resolve(proposedDir, file));
+    merged = merged.concat(batch);
+    console.log(`  + ${file} (${batch.length} records)`);
+  }
+
+  const outPath = resolve(proposedDir, `${contentType}.json`);
+  await writeFile(outPath, `${JSON.stringify(merged, null, 2)}\n`, 'utf-8');
+  console.log(
+    `\nMerged ${files.length} batch file(s), ${merged.length} total records -> ${outPath}`,
+  );
+
+  if (files.length === 0 && !(await pathExists(outPath))) {
+    console.warn(
+      `No batch files found matching ${batchPrefix}*.json in ${proposedDir}`,
+    );
+  }
+}
+
+function parseArgs(argv) {
+  const args = { contentType: null, language: null, runId: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--language') args.language = argv[++i];
+    else if (argv[i] === '--content-type') args.contentType = argv[++i];
+    else if (argv[i] === '--run-id') args.runId = argv[++i];
+  }
+  return args;
+}
+
+await main();

--- a/scripts/i18n-quality/prompts/grounding-agent.md
+++ b/scripts/i18n-quality/prompts/grounding-agent.md
@@ -1,0 +1,76 @@
+# Grounding agent prompt template
+
+One invocation per language. Produces `scripts/i18n-quality/glossaries/<lang>.json`.
+
+## Inputs
+
+- `scripts/i18n-quality/jw-terms-seed.json` — the curated list of JW-organizational
+  terms actually used in this app, each with English context.
+- The target language's name (English + native, from `src/constants/locales.ts`).
+
+## Task
+
+**Start here**: jw.org publishes an official terminology guide for media/
+government representatives at
+<https://www.jw.org/en/global-communications/terminology-guide/> — it's the
+organization's own canonical list of preferred terms, and it's translated
+into many languages. Fetch the English page and parse its `<head>` for
+`<link rel="alternate" hreflang="<lang>" href="...">` tags to find the exact
+URL of the target language's version directly (don't guess a URL by pattern
+
+- read it from the page's own hreflang metadata). If the target language has
+  a version of this page, treat it as your primary source and cite it for
+  every seed term it covers.
+
+For any seed term the terminology guide doesn't cover, fall back to
+searching **only jw.org / www.jw.org** (via WebSearch with
+`allowed_domains: ["jw.org", "www.jw.org"]`, and WebFetch on the resulting
+pages). Prefer authoritative, general-audience pages: organizational
+structure / "who we are" pages, Bible-terms glossary pages, JW Library help
+pages — not forums, not third-party sites, not machine-translated
+aggregators.
+
+**Batch your research.** Don't do one search per term — find a small number
+of dense reference pages (e.g. the language's own "About Us" / organizational
+page, a Bible-terms glossary page) that between them cover most of the seed
+list, and extract many terms per fetch. With ~28 seed terms, aim for 5-10
+total fetches, not 28.
+
+For each term, record:
+
+- `termEn`: the seed term.
+- `official`: the official target-language rendering as jw.org itself uses it.
+- `sourceUrls`: the jw.org URL(s) you found it on.
+- `confidence`: `high` (seen verbatim on an authoritative page), `medium`
+  (inferred from a closely related page), or `low` (could not find a clear
+  official rendering — say so rather than guessing).
+- `notes`: anything a reviewer should know (e.g. regional variants, a term
+  that jw.org itself renders inconsistently).
+
+If you cannot find an official rendering for a term after a reasonable
+search, record it with `confidence: "low"` and an empty `official` field
+rather than inventing one.
+
+## Output
+
+Write `scripts/i18n-quality/glossaries/<lang>.json`:
+
+```json
+{
+  "_comment": "Grounded JW terminology for <lang>, cross-checked against official jw.org pages. Reusable beyond translation-quality review. Regenerate via scripts/i18n-quality/prompts/grounding-agent.md.",
+  "_fetchedAt": "<ISO date>",
+  "_language": "<lang>",
+  "terms": [
+    {
+      "termEn": "...",
+      "official": "...",
+      "sourceUrls": ["..."],
+      "confidence": "...",
+      "notes": ""
+    }
+  ]
+}
+```
+
+This file is committed to the repo — it has lasting value as a reference
+independent of any single review run.

--- a/scripts/i18n-quality/prompts/grounding-agent.md
+++ b/scripts/i18n-quality/prompts/grounding-agent.md
@@ -39,6 +39,15 @@ structure / "who we are" pages, Bible-terms glossary pages, JW Library help
 pages — not forums, not third-party sites, not machine-translated
 aggregators.
 
+**wol.jw.org glossary/index entries share numeric IDs across languages** -
+a page at `wol.jw.org/en/wol/d/r1/lp-e/<id>` has the identical entry at
+`wol.jw.org/<lang>/wol/d/r<region>/lp-<lang-code>/<id>` in another language.
+When you find an English WOL page defining a term you need, try substituting
+just the language segment (and its `lp-` code) into the same numeric ID
+rather than searching for the target-language page separately - this found
+several otherwise-hard-to-locate terms (Congregation Bible Study, public
+talk, songbook, yeartext, etc.) directly.
+
 **Batch your research.** Don't do one search per term — find a small number
 of dense reference pages (e.g. the language's own "About Us" / organizational
 page, a Bible-terms glossary page) that between them cover most of the seed

--- a/scripts/i18n-quality/prompts/grounding-agent.md
+++ b/scripts/i18n-quality/prompts/grounding-agent.md
@@ -22,6 +22,15 @@ URL of the target language's version directly (don't guess a URL by pattern
   a version of this page, treat it as your primary source and cite it for
   every seed term it covers.
 
+**If WebFetch can't find the `hreflang` tags or gives you a lossy/summarized
+read of a page** (its markdown conversion sometimes drops `<head>` content
+entirely, and its summarization model can mangle non-Latin scripts when
+extracting quotes verbatim): fall back to a raw fetch via the Bash tool,
+e.g. `curl -s <url>`, and grep/read the raw HTML or text yourself instead of
+relying on WebFetch's summary. This matters most for the exact `official`
+term string and its surrounding quoted definition — get those from raw text,
+not a paraphrase.
+
 For any seed term the terminology guide doesn't cover, fall back to
 searching **only jw.org / www.jw.org** (via WebSearch with
 `allowed_domains: ["jw.org", "www.jw.org"]`, and WebFetch on the resulting

--- a/scripts/i18n-quality/prompts/review-short-strings.md
+++ b/scripts/i18n-quality/prompts/review-short-strings.md
@@ -1,0 +1,69 @@
+# Short-strings review agent prompt template
+
+One invocation per (language, batch of ~150 corpus records). Consumes a
+slice of `reports/translation-quality/<run-id>/corpus/<lang>/<contentType>.json`
+plus `scripts/i18n-quality/glossaries/<lang>.json`. Produces one entry per
+proposed change, appended to
+`reports/translation-quality/<run-id>/proposed/<lang>/<contentType>.json`.
+
+## Task
+
+For each record in the batch, compare `currentTranslation` against
+`sourceEn` and judge two **independent** things:
+
+1. **Phrasing** — does the translation read naturally in the target
+   language? Only propose a change when you can name a specific
+   grammatical or idiomatic problem. "This is one of several valid
+   phrasings" is not a reason to change it — leave it alone.
+2. **Terminology** — does the translation use JW-organizational vocabulary
+   correctly? Only propose a change when it's a genuine mismatch against
+   the glossary (or a fresh jw.org lookup you can cite), never a stylistic
+   preference. Most strings don't touch JW-specific vocabulary at all —
+   this check simply doesn't apply to them.
+
+## Mandatory constraints
+
+1. **Never touch `@:key` / `@:{'key'}` / `{param}` tokens.** They're listed
+   per-record in `protectedTokens`. Reword the prose around them, but the
+   exact token substrings must appear unchanged in your proposal — this is
+   mechanically re-verified afterward and silently rejected if violated.
+2. **Never re-flag Crowdin corruption** (typographic quotes, doubled
+   anchors, scrambled version numbers, mangled `@:` syntax) — that's a
+   separate pipeline's job and is already excluded from your corpus.
+3. **Every proposal needs a non-empty `reason`** an admin with zero context
+   can act on, and a `category` of exactly `"phrasing"` or `"terminology"`.
+4. **Mark `confidence` honestly** (`high`/`medium`/`low`) — be more
+   conservative in lower-resource languages where your own fluency is
+   weaker.
+5. **Do not invent translations for missing strings** — every record you
+   receive is already confirmed translated; this is a refinement pass, not
+   a translation pass.
+6. **When in doubt, propose nothing.** A missed improvement costs nothing;
+   a bad "fix" costs review time and may damage a correct translation. Do
+   not aim for a target flag rate — most strings should need no change.
+
+## Output format
+
+Only emit records for strings you're proposing a change to (skip the rest
+entirely — don't emit a "no change" record). Each proposed record:
+
+```json
+{
+  "id": "<sha1 of contentType|filePath|key|language>",
+  "language": "<lang>",
+  "contentType": "<i18n|docs-locale>",
+  "filePath": "<from the corpus record>",
+  "key": "<from the corpus record>",
+  "sourceEn": "<from the corpus record>",
+  "currentTranslation": "<from the corpus record>",
+  "proposedTranslation": "<your proposed replacement text>",
+  "protectedTokens": "<copy verbatim from the corpus record>",
+  "category": "phrasing|terminology",
+  "reason": "<specific, admin-readable explanation>",
+  "glossaryRefs": [{ "termEn": "...", "official": "...", "sourceUrl": "..." }],
+  "confidence": "high|medium|low"
+}
+```
+
+`glossaryRefs` is only populated for `terminology` proposals, citing the
+glossary entry (or a fresh jw.org URL) that justifies the change.

--- a/scripts/i18n-quality/split-into-batches.mjs
+++ b/scripts/i18n-quality/split-into-batches.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Splits a corpus/<lang>/<contentType>.json array into fixed-size batch
+ * files for review-agent invocations (prompts/review-short-strings.md is
+ * written for ~150 records per invocation - large enough to be efficient,
+ * small enough to stay a careful read rather than a shallow skim).
+ *
+ * Usage:
+ *   node scripts/i18n-quality/split-into-batches.mjs --run-id <id> --language fr --content-type i18n [--batch-size 150]
+ */
+import fsx from 'fs-extra';
+import { resolve } from 'node:path';
+
+const { ensureDir, readJson, writeFile } = fsx;
+
+async function main() {
+  const { batchSize, contentType, language, runId } = parseArgs(
+    process.argv.slice(2),
+  );
+  if (!language || !contentType || !runId) {
+    console.error(
+      'Usage: node split-into-batches.mjs --run-id <id> --language <code> --content-type <type> [--batch-size 150]',
+    );
+    process.exit(1);
+  }
+
+  const corpusPath = resolve(
+    'reports/translation-quality',
+    runId,
+    'corpus',
+    language,
+    `${contentType}.json`,
+  );
+  const records = await readJson(corpusPath);
+
+  const batchDir = resolve(
+    'reports/translation-quality',
+    runId,
+    'corpus',
+    language,
+    `${contentType}-batches`,
+  );
+  await ensureDir(batchDir);
+
+  const batchCount = Math.ceil(records.length / batchSize);
+  for (let i = 0; i < batchCount; i += 1) {
+    const batch = records.slice(i * batchSize, (i + 1) * batchSize);
+    const outPath = resolve(batchDir, `batch-${i + 1}.json`);
+    await writeFile(outPath, `${JSON.stringify(batch, null, 2)}\n`, 'utf-8');
+    console.log(`Wrote ${outPath} (${batch.length} records)`);
+  }
+
+  console.log(
+    `\n${records.length} records -> ${batchCount} batch(es) in ${batchDir}`,
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    batchSize: 150,
+    contentType: null,
+    language: null,
+    runId: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--language') args.language = argv[++i];
+    else if (argv[i] === '--content-type') args.contentType = argv[++i];
+    else if (argv[i] === '--run-id') args.runId = argv[++i];
+    else if (argv[i] === '--batch-size') args.batchSize = Number(argv[++i]);
+  }
+  return args;
+}
+
+await main();

--- a/scripts/i18n-quality/validate-proposed-changes.mjs
+++ b/scripts/i18n-quality/validate-proposed-changes.mjs
@@ -5,9 +5,11 @@
  * before a human ever sees it.
  *
  * Rejects (moves to rejected-by-guardrail/, never silently drops):
- *  - a proposal whose `@:key`/`{param}` token multiset doesn't exactly
- *    match the source's (a review agent must never touch these tokens -
- *    this is the mechanical re-verification, not just trusting the prompt).
+ *  - a proposal that drops an `@:key`/`{param}` token the current
+ *    translation already had, or introduces one that isn't a legitimate
+ *    restoration of something present in the English source (see
+ *    protectedTokensOk) - a review agent must never touch these tokens,
+ *    this is the mechanical re-verification, not just trusting the prompt.
  *  - a proposal whose recorded `currentTranslation` no longer matches what
  *    is actually checked out in the repo right now (stale - something else
  *    changed it since extraction).
@@ -37,12 +39,11 @@ const REPO_ROOT = resolve(__dirname, '../..');
 const FLAG_RATE_WARNING_THRESHOLD = 0.4;
 const VALID_CATEGORIES = new Set(['phrasing', 'terminology']);
 
-const LINK_TARGET_RE = /@:\{?'?([^'}\s]+)'?\}?/g;
+// See extract-review-corpus.mjs's matching constant for why this excludes
+// trailing sentence punctuation, unlike cleanup-crowdin.mjs's same-purpose
+// regex.
+const LINK_TARGET_RE = /@:\{?'?([^'}\s,.;:!?)]+)'?\}?/g;
 const PARAM_NAME_RE = /\{([\w]+)\}/g;
-
-function arraysEqual(a, b) {
-  return a.length === b.length && a.every((value, index) => value === b[index]);
-}
 
 function extractTokens(text) {
   return {
@@ -158,6 +159,32 @@ async function main() {
   console.log(`\nWrote ${resolve(runDir, 'SUMMARY.md')}`);
 }
 
+/** Does `superset` (as a multiset) contain at least as many of each item as `subset`? */
+function multisetContainsAll(superset, subset) {
+  const superCounts = toMultiset(superset);
+  const subCounts = toMultiset(subset);
+  for (const [item, count] of subCounts) {
+    if ((superCounts.get(item) ?? 0) < count) return false;
+  }
+  return true;
+}
+
+/** Items in `items` beyond what's already accounted for by `baseline` (multiset difference). */
+function multisetExtra(items, baseline) {
+  const baseCounts = toMultiset(baseline);
+  const used = new Map();
+  const extra = [];
+  for (const item of items) {
+    const usedCount = used.get(item) ?? 0;
+    if (usedCount < (baseCounts.get(item) ?? 0)) {
+      used.set(item, usedCount + 1);
+    } else {
+      extra.push(item);
+    }
+  }
+  return extra;
+}
+
 function parseArgs(argv) {
   const args = { language: null, runId: null };
   for (let i = 0; i < argv.length; i += 1) {
@@ -172,15 +199,34 @@ function parseArgs(argv) {
   return args;
 }
 
+/**
+ * A proposal may never *remove* a link/param token the current translation
+ * already had, but *may* restore one the current translation was missing
+ * relative to source (e.g. a dropped {count} or @:key) - and a pre-existing
+ * gap between current and source that the edit doesn't touch (e.g. a link
+ * already inlined as literal text in the current translation) must not be
+ * treated as something this proposal broke.
+ */
+function protectedTokensOk(sourceTokens, currentTokens, proposedTokens) {
+  return ['links', 'params'].every((dimension) => {
+    const source = sourceTokens[dimension];
+    const current = currentTokens[dimension];
+    const proposed = proposedTokens[dimension];
+    if (!multisetContainsAll(proposed, current)) return false;
+    const proposedExtra = multisetExtra(proposed, current);
+    const restorableFromSource = multisetExtra(source, current);
+    return multisetContainsAll(restorableFromSource, proposedExtra);
+  });
+}
+
 function reject(record, reasonCode) {
   return { ...record, _rejectionReason: reasonCode };
 }
 
-function tokensMatch(expected, actual) {
-  return (
-    arraysEqual([...expected.links].sort(), actual.links) &&
-    arraysEqual([...expected.params].sort(), actual.params)
-  );
+function toMultiset(items) {
+  const counts = new Map();
+  for (const item of items) counts.set(item, (counts.get(item) ?? 0) + 1);
+  return counts;
 }
 
 async function validateOne(record, corpusIndex) {
@@ -210,17 +256,14 @@ async function validateOne(record, corpusIndex) {
     return reject(record, 'stale-current-translation-changed');
   }
 
-  // Compare tokens against the CURRENT translation (same language, same
-  // regex, same punctuation-adjacency behavior), not the corpus record's
-  // English-derived protectedTokens: vue-i18n's actual `@:key` grammar has
-  // no stop character before punctuation, so a bare link immediately
-  // followed by e.g. a comma (common in Russian, rare in English "@:key ")
-  // genuinely includes that punctuation in the parsed key. Comparing against
-  // English's differently-punctuated boundary produces false rejections;
-  // what matters is whether the *edit* changed the token, not whether it
-  // matches English's incidental trailing character.
+  // Three-way check against source/current/proposed (see protectedTokensOk):
+  // a proposal may never drop a token the current translation already had,
+  // may restore one current was missing relative to source, but a
+  // pre-existing current-vs-source gap the edit doesn't touch (e.g. a link
+  // already inlined as literal text) is not this proposal's fault.
   if (
-    !tokensMatch(
+    !protectedTokensOk(
+      corpusRecord.protectedTokens,
       extractTokens(record.currentTranslation),
       extractTokens(record.proposedTranslation),
     )

--- a/scripts/i18n-quality/validate-proposed-changes.mjs
+++ b/scripts/i18n-quality/validate-proposed-changes.mjs
@@ -210,8 +210,21 @@ async function validateOne(record, corpusIndex) {
     return reject(record, 'stale-current-translation-changed');
   }
 
-  const actualTokens = extractTokens(record.proposedTranslation);
-  if (!tokensMatch(corpusRecord.protectedTokens, actualTokens)) {
+  // Compare tokens against the CURRENT translation (same language, same
+  // regex, same punctuation-adjacency behavior), not the corpus record's
+  // English-derived protectedTokens: vue-i18n's actual `@:key` grammar has
+  // no stop character before punctuation, so a bare link immediately
+  // followed by e.g. a comma (common in Russian, rare in English "@:key ")
+  // genuinely includes that punctuation in the parsed key. Comparing against
+  // English's differently-punctuated boundary produces false rejections;
+  // what matters is whether the *edit* changed the token, not whether it
+  // matches English's incidental trailing character.
+  if (
+    !tokensMatch(
+      extractTokens(record.currentTranslation),
+      extractTokens(record.proposedTranslation),
+    )
+  ) {
     return reject(record, 'protected-token-mismatch');
   }
 

--- a/scripts/i18n-quality/validate-proposed-changes.mjs
+++ b/scripts/i18n-quality/validate-proposed-changes.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Phase 2.5 of the translation-quality pipeline: a deterministic,
+ * LLM-free guardrail gate that runs on every raw review-agent proposal
+ * before a human ever sees it.
+ *
+ * Rejects (moves to rejected-by-guardrail/, never silently drops):
+ *  - a proposal whose `@:key`/`{param}` token multiset doesn't exactly
+ *    match the source's (a review agent must never touch these tokens -
+ *    this is the mechanical re-verification, not just trusting the prompt).
+ *  - a proposal whose recorded `currentTranslation` no longer matches what
+ *    is actually checked out in the repo right now (stale - something else
+ *    changed it since extraction).
+ *  - a no-op (`proposedTranslation === currentTranslation`).
+ *  - anything missing a non-empty `reason` or a valid `category`.
+ *  - (i18n content type only) anything that fails to compile as a vue-i18n
+ *    message, reusing scripts/fix-i18n-locales.mjs's `compiles()`.
+ *
+ * Everything else lands in validated/. Also computes a per-file flag rate
+ * (proposed / corpus size) and calls out anything over 40% in SUMMARY.md as
+ * worth spot-checking for over-eager rewriting before trusting the batch.
+ *
+ * Usage:
+ *   node scripts/i18n-quality/validate-proposed-changes.mjs --run-id <id> --language fr
+ */
+import fsx from 'fs-extra';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { compiles } from '../fix-i18n-locales.mjs';
+
+const { ensureDir, pathExists, readFile, readJson, writeFile } = fsx;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, '../..');
+const FLAG_RATE_WARNING_THRESHOLD = 0.4;
+const VALID_CATEGORIES = new Set(['phrasing', 'terminology']);
+
+const LINK_TARGET_RE = /@:\{?'?([^'}\s]+)'?\}?/g;
+const PARAM_NAME_RE = /\{([\w]+)\}/g;
+
+function arraysEqual(a, b) {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function extractTokens(text) {
+  return {
+    links: [...text.matchAll(LINK_TARGET_RE)].map((m) => m[1]).sort(),
+    params: [...text.matchAll(PARAM_NAME_RE)].map((m) => m[1]).sort(),
+  };
+}
+
+async function getCurrentTranslation(filePath, key) {
+  const fullPath = resolve(REPO_ROOT, filePath);
+  if (!(await pathExists(fullPath))) return undefined;
+  const data = JSON.parse(await readFile(fullPath, 'utf-8'));
+  return data[key];
+}
+
+async function main() {
+  const { language, runId } = parseArgs(process.argv.slice(2));
+  if (!language || !runId) {
+    console.error(
+      'Usage: node validate-proposed-changes.mjs --run-id <id> --language <code>',
+    );
+    process.exit(1);
+  }
+
+  const runDir = resolve(REPO_ROOT, 'reports/translation-quality', runId);
+  const proposedDir = resolve(runDir, 'proposed', language);
+  const corpusDir = resolve(runDir, 'corpus', language);
+  const validatedDir = resolve(runDir, 'validated', language);
+  const rejectedDir = resolve(runDir, 'rejected-by-guardrail', language);
+  await ensureDir(validatedDir);
+  await ensureDir(rejectedDir);
+
+  if (!(await pathExists(proposedDir))) {
+    console.error(`No proposed/ directory found at ${proposedDir}`);
+    process.exit(1);
+  }
+
+  // Skip merge-batches.mjs's intermediate per-batch files
+  // (<contentType>-batch-N.json) - only the merged <contentType>.json files
+  // are real content types to validate.
+  const contentTypeFiles = (await fsx.readdir(proposedDir)).filter(
+    (f) => f.endsWith('.json') && !/-batch-\d+\.json$/.test(f),
+  );
+
+  const summaryLines = [
+    `# Validation summary - ${language} (run ${runId})`,
+    '',
+    '| Content type | Corpus size | Proposed | Validated | Rejected | Flag rate |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ];
+  const warnings = [];
+
+  for (const file of contentTypeFiles) {
+    const contentType = file.replace(/\.json$/, '');
+    const proposed = await readJson(resolve(proposedDir, file));
+    const corpus = await readJson(resolve(corpusDir, file));
+    const corpusIndex = new Map(corpus.map((r) => [r.key, r]));
+
+    const validated = [];
+    const rejected = [];
+    for (const record of proposed) {
+      const result = await validateOne(record, corpusIndex);
+      if (result.status === 'validated') validated.push(result);
+      else rejected.push(result);
+    }
+
+    await writeFile(
+      resolve(validatedDir, file),
+      `${JSON.stringify(validated, null, 2)}\n`,
+      'utf-8',
+    );
+    await writeFile(
+      resolve(rejectedDir, file),
+      `${JSON.stringify(rejected, null, 2)}\n`,
+      'utf-8',
+    );
+
+    const flagRate = corpus.length > 0 ? proposed.length / corpus.length : 0;
+    summaryLines.push(
+      `| ${contentType} | ${corpus.length} | ${proposed.length} | ${validated.length} | ${rejected.length} | ${(flagRate * 100).toFixed(1)}% |`,
+    );
+    if (flagRate > FLAG_RATE_WARNING_THRESHOLD) {
+      warnings.push(
+        `**${contentType}**: flag rate ${(flagRate * 100).toFixed(1)}% (${proposed.length}/${corpus.length}) is above the ${FLAG_RATE_WARNING_THRESHOLD * 100}% threshold - spot-check this batch for over-eager rewriting before trusting it.`,
+      );
+    }
+
+    console.log(
+      `[${contentType}] ${language}: ${proposed.length} proposed -> ${validated.length} validated, ${rejected.length} rejected`,
+    );
+    if (rejected.length > 0) {
+      const reasonCounts = {};
+      for (const r of rejected) {
+        reasonCounts[r._rejectionReason] =
+          (reasonCounts[r._rejectionReason] ?? 0) + 1;
+      }
+      console.log(`  rejection reasons: ${JSON.stringify(reasonCounts)}`);
+    }
+  }
+
+  summaryLines.push('');
+  if (warnings.length > 0) {
+    summaryLines.push('## Warnings', '', ...warnings.map((w) => `- ${w}`));
+  } else {
+    summaryLines.push('No flag-rate warnings.');
+  }
+
+  await writeFile(
+    resolve(runDir, 'SUMMARY.md'),
+    `${summaryLines.join('\n')}\n`,
+    'utf-8',
+  );
+  console.log(`\nWrote ${resolve(runDir, 'SUMMARY.md')}`);
+}
+
+function parseArgs(argv) {
+  const args = { language: null, runId: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--language') {
+      args.language = argv[i + 1];
+      i += 1;
+    } else if (argv[i] === '--run-id') {
+      args.runId = argv[i + 1];
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function reject(record, reasonCode) {
+  return { ...record, _rejectionReason: reasonCode };
+}
+
+function tokensMatch(expected, actual) {
+  return (
+    arraysEqual([...expected.links].sort(), actual.links) &&
+    arraysEqual([...expected.params].sort(), actual.params)
+  );
+}
+
+async function validateOne(record, corpusIndex) {
+  if (typeof record.reason !== 'string' || record.reason.trim() === '') {
+    return reject(record, 'missing-reason');
+  }
+  if (!VALID_CATEGORIES.has(record.category)) {
+    return reject(record, 'invalid-category');
+  }
+  if (
+    typeof record.proposedTranslation !== 'string' ||
+    record.proposedTranslation.trim() === ''
+  ) {
+    return reject(record, 'empty-proposal');
+  }
+  if (record.proposedTranslation === record.currentTranslation) {
+    return reject(record, 'no-op');
+  }
+
+  const corpusRecord = corpusIndex.get(record.key);
+  if (!corpusRecord) {
+    return reject(record, 'unknown-key-not-in-corpus');
+  }
+
+  const liveCurrent = await getCurrentTranslation(record.filePath, record.key);
+  if (liveCurrent !== record.currentTranslation) {
+    return reject(record, 'stale-current-translation-changed');
+  }
+
+  const actualTokens = extractTokens(record.proposedTranslation);
+  if (!tokensMatch(corpusRecord.protectedTokens, actualTokens)) {
+    return reject(record, 'protected-token-mismatch');
+  }
+
+  if (
+    record.contentType === 'i18n' &&
+    record.proposedTranslation.includes('@:') &&
+    !compiles(record.proposedTranslation)
+  ) {
+    return reject(record, 'fails-vue-i18n-compile');
+  }
+
+  return { ...record, status: 'validated' };
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Adds `scripts/i18n-quality/` — a translation-**quality** review pipeline (naturalness + JW-appropriate terminology), distinct from the existing Crowdin-corruption-repair tooling (`cleanup-crowdin.mjs`, `fix-i18n-locales.mjs`, `fix-doc-markdown.mjs`), which only catches mechanical breakage.
- Pipeline: a deterministic corpus extractor → a jw.org-grounded per-language terminology glossary (built from jw.org's own official [Terminology Guide](https://www.jw.org/en/global-communications/terminology-guide/)/"Lexique", located via its `hreflang` alternate-language links) → batched LLM review → a deterministic guardrail validator (rejects anything that mangles a protected `@:`/`{param}` token, is stale against the live repo, is a no-op, or fails vue-i18n compilation) → a Markdown report → a dry-run-by-default Crowdin API apply step.
- Nothing is auto-applied. Every proposed change carries an admin-readable reason; `apply-translation-quality-fixes.mjs` only ever acts on entries a human has explicitly marked `"status": "approved"`, and always re-checks the live Crowdin text immediately before writing (skips anything changed since review rather than clobbering it).
- `scripts/i18n-quality/glossaries/fr.json` is committed as a durable, reusable reference beyond this one review.

## Pilot results (not included in this PR — gitignored per-run output)
Piloted end-to-end on French `src/i18n/en.json` + `docs/locales/en.json` content: 977 translated strings reviewed, 46 proposed changes (4 terminology, 42 phrasing) survived the guardrail gate — a healthy ~4.7% flag rate, no over-eager-rewriting warnings. Full report at `reports/translation-quality/pilot-fr-2026-09-10/validated/fr/{i18n,docs-locale}.md` locally.

## Explicitly deferred
- Rolling this to the other 13 shipped languages.
- Long-form prose review (`docs/src/**`, `release-notes/*.md`) — different chunking/lookup design needed.
- Actually running `--apply` — pending review/approval of the pilot's proposed changes.

## Test plan
- [x] `node scripts/cleanup-crowdin.mjs --selftest` — 42/42 pass (unmodified, unaffected)
- [x] All 6 new `.mjs` scripts pass `eslint -c ./eslint.config.js`
- [x] End-to-end dry run: extractor → 7×i18n + 1×docs-locale batches → merge → validate → report, all mechanically verified (protected-token preservation, staleness detection against live files, vue-i18n compile check)
- [x] Guardrail validator exercised against hand-crafted fixtures covering every rejection path (token mismatch, no-op, missing reason, stale) before trusting it on real agent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)