### PR TITLE
fix(crowdin): preserve punctuation when repairing a bare @:key link

### DIFF
--- a/scripts/cleanup-crowdin.mjs
+++ b/scripts/cleanup-crowdin.mjs
@@ -158,9 +158,31 @@ function computeLinkTargetFix(source, translation, validKeys) {
   );
   if (!isCompound && danglingLinks.length === 1 && missingLinks.length === 1) {
     const match = danglingLinks[0];
+    const correctKey = missingLinks[0];
+    // vue-i18n's `@:key` grammar has no punctuation stop character (only
+    // whitespace/{@/()/ ends a bare link target), so a *bare* key
+    // immediately followed by punctuation with no space - e.g. Russian
+    // "@:obsStudio," - genuinely parses with the punctuation attached,
+    // making LINK_TARGET_RE capture it as part of `key` too. Naively
+    // replacing that whole captured key with the correct one would delete
+    // the punctuation outright (e.g. "@:obsStudio, которая" ->
+    // "@:obsStudio которая", dropping a grammatically required comma). Only
+    // for that bare-form case - not an already-braced `@:{cbsx}` style
+    // corruption, where the braces already bound the key correctly and a
+    // plain substring swap is the right fix - switch to the explicit braced
+    // form (`@:{'key'}`), which unambiguously bounds the key and lets
+    // vue-i18n parse the trailing punctuation as ordinary text instead.
+    const wasBareForm = !match.full.includes('{');
+    const trailingJunk =
+      wasBareForm && match.key.startsWith(correctKey)
+        ? match.key.slice(correctKey.length)
+        : '';
+    const replacement = trailingJunk
+      ? `@:{'${correctKey}'}${trailingJunk}`
+      : match.full.replace(match.key, correctKey);
     fixed =
       fixed.slice(0, match.index) +
-      match.full.replace(match.key, missingLinks[0]) +
+      replacement +
       fixed.slice(match.index + match.full.length);
   }
 
@@ -1197,6 +1219,30 @@ function runSelfTest() {
           {
             kind: 'links',
             text: 'Če vnešeno, bo M³ izpustil medije za @:{cbs}.',
+          },
+        ],
+        [
+          'link bare key glued to trailing punctuation isolated with braces',
+          computeLinkTargetFix(
+            'The scene in @:obsStudio that will be used as the default stage view.',
+            'Сцена в @:obsStudio, которая будет использоваться по умолчанию.',
+            keys,
+          ),
+          {
+            kind: 'links',
+            text: "Сцена в @:{'obsStudio'}, которая будет использоваться по умолчанию.",
+          },
+        ],
+        [
+          'link bare key glued to trailing punctuation (period) isolated with braces',
+          computeLinkTargetFix(
+            '@:obsStudio is a free app.',
+            '@:obsStudio.',
+            keys,
+          ),
+          {
+            kind: 'links',
+            text: "@:{'obsStudio'}.",
           },
         ],
         [


### PR DESCRIPTION
## Summary
- `scripts/cleanup-crowdin.mjs`'s class-5 dangling-`@:`-link repair (`computeLinkTargetFix`) correctly *detects* a bare `@:key` glued to trailing punctuation with no space (e.g. Russian `@:obsStudio,`) as dangling — vue-i18n's actual `@:key` grammar has no punctuation stop character, so it genuinely parses the punctuation as part of the key, making the reference unresolvable. But the repair's fix (`match.full.replace(match.key, correctKey)`) replaced the *whole* captured key, punctuation included — silently deleting it instead of preserving it.
- **Confirmed live**: `ru`'s `obsCameraScene-explain` read `"...@:obsStudio, которая..."` before an hourly/push-triggered autorepair sweep touched it, and `"...@:obsStudio которая..."` after — the comma dropped, breaking a grammatically required comma before a relative clause. Manually restored the correct text via the API after verifying this fix reproduces the right behavior (see commit for the exact live translationId/before/after).
- Fix: when the dangling key is exactly the correct key plus trailing junk, and the original was in **bare** form (no braces), switch to the explicit `@:{'key'}` form instead of a same-shape substring swap — this unambiguously bounds the key so vue-i18n parses the trailing punctuation as ordinary text. An already-braced corruption (`@:{cbsx}` style) is untouched by this change and still gets the existing simple substring swap.

## Test plan
- [x] `node scripts/cleanup-crowdin.mjs --selftest` — 44/44 pass (42 pre-existing + 2 new cases for this exact bug), zero regressions on the 10 existing link-repair cases
- [x] Verified live against `@intlify/message-compiler`'s `baseCompile` that vue-i18n's `@:key` grammar has no punctuation stop character, and that the braced `@:{'key'}` form correctly isolates the key regardless of what immediately follows
- [x] Manually verified + restored the one live string this bug had already corrupted, via the Crowdin API

🤖 Generated with [Claude Code](https://claude.com/claude-code)