### PR TITLE
fix(docs): restore /es/ prefix on Spanish hero-action links

### DIFF
--- a/docs/src/es/index.md
+++ b/docs/src/es/index.md
@@ -9,19 +9,19 @@ hero:
   actions:
     - theme: brand
       text: Descargar
-      link: /download
+      link: /es/download
     - theme: brand
       text: Acerca de
-      link: /about
+      link: /es/about
     - theme: brand
       text: Guía del usuario
-      link: /user-guide
+      link: /es/user-guide
     - theme: brand
       text: Guía de configuración
-      link: /settings-guide
+      link: /es/settings-guide
     - theme: brand
       text: Preguntas frecuentes
-      link: /faq
+      link: /es/faq
 features:
   - icon: 🚀
     title: Administración automática de archivos multimedia


### PR DESCRIPTION
## Summary
- `docs/src/es/index.md`'s Download/About/User Guide/Settings Guide/FAQ hero links were exported without their locale prefix, falling back to the literal English path - this is what's currently failing the docs deploy (`docs/utils/__tests__/locales.test.ts`'s "should have correct links" test, blocking `Deploy Docs site to Pages`).
- This is a one-off content restore to unblock the deploy now. The durable, project-wide fix (so this stops recurring for every language) is #9203.

## Test plan
- [x] `docs/utils/__tests__/locales.test.ts` - 3/3 pass (was 1 failing)
- [x] `node docs/utils/fix-doc-markdown.mjs --check` - 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)